### PR TITLE
[Feature] 카테고리별 이벤트 조회 기능 구현

### DIFF
--- a/src/main/java/com/noljo/nolzo/event/controller/EventController.java
+++ b/src/main/java/com/noljo/nolzo/event/controller/EventController.java
@@ -26,8 +26,8 @@ public class EventController {
         return ResponseEntity.ok(eventService.save(dto));
     }
 
-    @GetMapping("/category/{category}")
-    public ResponseEntity<List<EventResponse>> getEventsByCategory(@PathVariable EventCategory category) {
+    @GetMapping
+    public ResponseEntity<List<EventResponse>> getEventsByCategory(@RequestParam EventCategory category) {
         return ResponseEntity.ok(eventService.findAllByCategory(category));
     }
 

--- a/src/main/java/com/noljo/nolzo/event/controller/EventController.java
+++ b/src/main/java/com/noljo/nolzo/event/controller/EventController.java
@@ -2,12 +2,12 @@ package com.noljo.nolzo.event.controller;
 
 import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.dto.EventResponse;
+import com.noljo.nolzo.event.entity.EventCategory;
 import com.noljo.nolzo.event.service.EventService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
 
 @RestController
@@ -24,6 +24,11 @@ public class EventController {
     @PostMapping("/")
     public ResponseEntity<EventResponse> createEvent(@RequestBody @Valid EventRequest dto) {
         return ResponseEntity.ok(eventService.save(dto));
+    }
+
+    @GetMapping("/category/{category}")
+    public ResponseEntity<List<EventResponse>> getEventsByCategory(@PathVariable EventCategory category) {
+        return ResponseEntity.ok(eventService.findAllByCategory(category));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/noljo/nolzo/event/entity/EventCategory.java
+++ b/src/main/java/com/noljo/nolzo/event/entity/EventCategory.java
@@ -1,5 +1,7 @@
 package com.noljo.nolzo.event.entity;
 
 public enum EventCategory {
-    CONCERT;
+    CONCERT,
+    MUSICAL,
+    PLAY;
 }

--- a/src/main/java/com/noljo/nolzo/event/repository/EventRepository.java
+++ b/src/main/java/com/noljo/nolzo/event/repository/EventRepository.java
@@ -1,9 +1,12 @@
 package com.noljo.nolzo.event.repository;
 
 import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.event.entity.EventCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
+    List<Event> findAllByEventCategory(EventCategory eventCategory);
 }

--- a/src/main/java/com/noljo/nolzo/event/service/EventService.java
+++ b/src/main/java/com/noljo/nolzo/event/service/EventService.java
@@ -3,6 +3,7 @@ package com.noljo.nolzo.event.service;
 import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.dto.EventResponse;
 import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.event.entity.EventCategory;
 import com.noljo.nolzo.event.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,13 @@ public class EventService {
     @Transactional(readOnly = true)
     public List<EventResponse> findAll() {
         return eventRepository.findAll().stream()
+                .map(EventResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<EventResponse> findAllByCategory(EventCategory category) {
+        return eventRepository.findAllByEventCategory(category).stream()
                 .map(EventResponse::from)
                 .toList();
     }

--- a/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
@@ -2,12 +2,15 @@ package com.noljo.nolzo.domain.event.service;
 
 import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.dto.EventResponse;
+import com.noljo.nolzo.event.entity.EventCategory;
 import com.noljo.nolzo.event.service.EventService;
 import com.noljo.nolzo.support.annotation.ServiceTest;
 import com.noljo.nolzo.support.fixture.EventFixture;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
 
 @ServiceTest
 class EventServiceTest {
@@ -40,6 +43,32 @@ class EventServiceTest {
 
         Assertions.assertThat("Cats").isEqualTo(eventService.findById(id).getTitle());
     }
+
+    @Test
+    void 카테고리별_이벤트를_조회할_수_있다() {
+        EventRequest concertEvent = EventFixture.캣츠dto();
+        EventRequest hamletEvent = EventFixture.햄릿dto();
+        eventService.save(concertEvent);
+        eventService.save(hamletEvent);
+
+        List<EventResponse> concertEvents = eventService.findAllByCategory(EventCategory.CONCERT);
+
+        Assertions.assertThat(concertEvents).hasSize(2);
+        Assertions.assertThat(concertEvents)
+                .extracting("eventCategory")
+                .containsOnly(EventCategory.CONCERT);
+    }
+
+    @Test
+    void 존재하지_않는_카테고리의_이벤트_조회시_빈_리스트를_반환한다() {
+        EventRequest concertEvent = EventFixture.캣츠dto();  // CONCERT 카테고리
+        eventService.save(concertEvent);
+
+        List<EventResponse> otherEvents = eventService.findAllByCategory(EventCategory.MUSICAL);
+
+        Assertions.assertThat(otherEvents).isEmpty();
+    }
+
 
     @Test
     void 이벤트를_삭제할_수_있다(){


### PR DESCRIPTION
## 📌 개요
* 카테고리별 이벤트 조회 기능을 구현했습니다.

## 🛠️ 작업 내용
- [x] EventCategory 에 MUSICAL, PLAY 카테고리 추가
- [x] 카테고리별 이벤트 조회 API 기능 구현
- [x] 카테고리별 이벤트 조회 기능 테스트 코드 작성 및 결과 확인
- [x] 관련 이슈 번호 (`#29`)

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)
<img width="488" alt="스크린샷 2025-06-19 오후 2 35 01" src="https://github.com/user-attachments/assets/23fcc25c-befd-457d-9cbc-a50d2b40b38a" />

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.