### PR TITLE
[Feature] 날짜 및 시간 선택 기능 구현

### DIFF
--- a/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
+++ b/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
@@ -1,0 +1,23 @@
+package com.noljo.nolzo.reservation.controller;
+
+import com.noljo.nolzo.reservation.dto.EventDateTimeResponse;
+import com.noljo.nolzo.reservation.service.ReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @PostMapping("/{eventId}")
+    public ResponseEntity<EventDateTimeResponse> chooseEventDateTime(@PathVariable Long eventId) {
+
+        EventDateTimeResponse event = reservationService.chooseEventDateTime(eventId);
+        return ResponseEntity.ok(event);
+    }
+
+}

--- a/src/main/java/com/noljo/nolzo/reservation/dto/EventDateTimeResponse.java
+++ b/src/main/java/com/noljo/nolzo/reservation/dto/EventDateTimeResponse.java
@@ -1,0 +1,29 @@
+package com.noljo.nolzo.reservation.dto;
+
+import com.noljo.nolzo.event.entity.Event;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+public class EventDateTimeResponse {
+
+    private Long id;
+    private LocalDate showdate;
+    private LocalTime showTime;
+
+    private EventDateTimeResponse(Long id, LocalDate showdate, LocalTime showTime) {
+        this.id = id;
+        this.showdate = showdate;
+        this.showTime = showTime;
+    }
+
+    public static EventDateTimeResponse fromEvent(Event event){
+        return new EventDateTimeResponse(
+                event.getId(),
+                event.getSchedule().getShowDate(),
+                event.getSchedule().getShowTime()
+        );
+    }
+}

--- a/src/main/java/com/noljo/nolzo/reservation/entity/Reservation.java
+++ b/src/main/java/com/noljo/nolzo/reservation/entity/Reservation.java
@@ -26,7 +26,7 @@ public class Reservation extends BaseEntity {
 
     private int totalPrice;
 
-    private Long reservationNumber;
+    private String reservationNumber;
 
     @OneToMany(mappedBy = "reservation", cascade = CascadeType.PERSIST)
     private List<Ticket> tickets = new ArrayList<>();
@@ -36,7 +36,7 @@ public class Reservation extends BaseEntity {
     private Member member;
 
     @Builder
-    public Reservation(Long id, ReservationStatus status, int totalPrice, Long reservationNumber, Member member) {
+    public Reservation(Long id, ReservationStatus status, int totalPrice, String reservationNumber, Member member) {
         this.id = id;
         this.status = status;
         this.totalPrice = totalPrice;

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -1,0 +1,28 @@
+package com.noljo.nolzo.reservation.service;
+
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.event.repository.EventRepository;
+import com.noljo.nolzo.reservation.dto.EventDateTimeResponse;
+import com.noljo.nolzo.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final EventRepository eventRepository;
+
+    public EventDateTimeResponse chooseEventDateTime(Long eventId) {
+
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이벤트가 존재하지 않습니다"));
+        return EventDateTimeResponse.fromEvent(event);
+    }
+
+
+
+}

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -16,7 +16,7 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final EventRepository eventRepository;
 
-    public EventDateTimeResponse getSelectedEventDateTime(Long eventId) {
+    public EventDateTimeResponse readSelectedEventDateTime(Long eventId) {
 
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 이벤트가 존재하지 않습니다"));

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -16,7 +16,7 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final EventRepository eventRepository;
 
-    public EventDateTimeResponse chooseEventDateTime(Long eventId) {
+    public EventDateTimeResponse getSelectedEventDateTime(Long eventId) {
 
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 이벤트가 존재하지 않습니다"));

--- a/src/test/java/com/noljo/nolzo/domain/Reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/Reservation/service/ReservationServiceTest.java
@@ -1,0 +1,39 @@
+package com.noljo.nolzo.domain.Reservation.service;
+
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.event.repository.EventRepository;
+import com.noljo.nolzo.reservation.dto.EventDateTimeResponse;
+import com.noljo.nolzo.reservation.service.ReservationService;
+import com.noljo.nolzo.support.annotation.ServiceTest;
+import com.noljo.nolzo.support.fixture.EventFixture;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+
+@ServiceTest
+public class ReservationServiceTest {
+
+    @Autowired
+    private ReservationService reservationService;
+    @Autowired
+    private EventRepository eventRepository;
+
+
+    @Test
+    public void 공연에_대한_날짜_시간_선택할_수_있다() throws Exception {
+        //given
+        Event event = eventRepository.save(EventFixture.캣츠());
+
+        //when
+        EventDateTimeResponse response = reservationService.chooseEventDateTime(event.getId());
+
+        //then
+        assertNotNull(response);
+        assertEquals(event.getId(), response.getId());
+        assertNotNull(response.getShowdate());
+        assertNotNull(response.getShowTime());
+        }
+}

--- a/src/test/java/com/noljo/nolzo/support/fixture/EventFixture.java
+++ b/src/test/java/com/noljo/nolzo/support/fixture/EventFixture.java
@@ -4,6 +4,8 @@ import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.entity.EventCategory;
 import java.time.LocalDate;
+import java.time.LocalTime;
+
 import com.noljo.nolzo.event.entity.Schedule;
 import lombok.Getter;
 
@@ -11,10 +13,10 @@ import lombok.Getter;
 public enum EventFixture {
     캣츠("Cats", "서울 예술의 전당", "세계적으로 유명한 뮤지컬, 고양이들의 이야기를 그린 작품입니다.",
             "https://example.com/cats.jpg", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 6, 30),
-            null, EventCategory.CONCERT, 180, 12, 5, 120),
+            new Schedule(LocalDate.of(2024, 5, 10), LocalTime.of(19, 30)), EventCategory.CONCERT, 180, 12, 5, 120),
     햄릿("Hamlet", "국립극장 해오름극장", "셰익스피어 4대 비극 중 하나인 '햄릿'의 현대적 재해석 공연입니다.",
             "https://example.com/hamlet.jpg", LocalDate.of(2025, 7, 1), LocalDate.of(2025, 7, 15),
-            null, EventCategory.CONCERT, 150, 15, 4, 80);
+            new Schedule(LocalDate.of(2024, 7, 10), LocalTime.of(18, 30)), EventCategory.CONCERT, 150, 15, 4, 80);
 
     private String title;
     private String venue;

--- a/src/test/java/com/noljo/nolzo/support/fixture/ReservationFixture.java
+++ b/src/test/java/com/noljo/nolzo/support/fixture/ReservationFixture.java
@@ -7,12 +7,12 @@ import lombok.Getter;
 
 @Getter
 public enum ReservationFixture {
-    예약(ReservationStatus.CONFIRMED, 15000, 12313123L); // 추후 총합가격 로직 추가시 수정
+    예약(ReservationStatus.CONFIRMED, 15000, "12313123L"); // 추후 총합가격 로직 추가시 수정
     private ReservationStatus reservationStatus;
     private int totalPrice;
-    private Long reservationNumber;
+    private String reservationNumber;
 
-    ReservationFixture(ReservationStatus reservationStatus, int totalPrice, Long reservationNumber) {
+    ReservationFixture(ReservationStatus reservationStatus, int totalPrice, String reservationNumber) {
         this.reservationStatus = reservationStatus;
         this.totalPrice = totalPrice;
         this.reservationNumber = reservationNumber;


### PR DESCRIPTION
## 📌 개요
- 예매 시 좌석 선택 전에 공연에 대한 날짜와 시간을 선택할 수 있다

## 🛠️ 작업 내용
- 공연 예매에 대한 날짜 및 시간 선택 API 작성(`chooseEventDateTime`) 
- 날짜,시간 선택 서비스 로직(`chooseEventDateTime`) 구현
- `EventDateTimeResponse ` DTO 작성
- `fromEvent` 정적 팩토리 매서드 작성 
- 테스트 코드 작성

## 📌 차후 계획 (Optional)
- @AuthentictionPripical을 통해 로그인한 사용자에 대한 검증하는 리팩토링 예정

## 📌 테스트 케이스
- 기능 정상 동작
- 새로운 의존성 추가 여부 없음
-  코드 스타일 및 컨벤션 준수
- 기존 테스트 통과 

Close #2 