### PR TITLE
[Feature] 이벤트 조회 클라이언트 대응 api 구현

### DIFF
--- a/src/main/java/com/noljo/nolzo/event/dto/EventDetailResponse.java
+++ b/src/main/java/com/noljo/nolzo/event/dto/EventDetailResponse.java
@@ -1,0 +1,37 @@
+package com.noljo.nolzo.event.dto;
+
+import com.noljo.nolzo.event.dto.internal.ScheduleInfo;
+import com.noljo.nolzo.event.entity.Event;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class EventDetailResponse {
+    private Long eventId;
+    private String title;
+    private String venue;
+    private String description;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private int ageLimit;
+    private String posterUrl;
+    private List<ScheduleInfo> schedules;
+
+    static public EventDetailResponse from(List<ScheduleInfo> scheduleInfos, Event event){
+        return EventDetailResponse.builder()
+                .eventId(event.getId())
+                .title(event.getTitle())
+                .venue(event.getVenue())
+                .description(event.getDescription())
+                .startDate(event.getStartDate())
+                .endDate(event.getEndDate())
+                .ageLimit(event.getAgeLimit())
+                .posterUrl(event.getPosterImageUrl())
+                .schedules(scheduleInfos)
+                .build();
+    }
+}

--- a/src/main/java/com/noljo/nolzo/event/dto/internal/ScheduleInfo.java
+++ b/src/main/java/com/noljo/nolzo/event/dto/internal/ScheduleInfo.java
@@ -1,0 +1,20 @@
+package com.noljo.nolzo.event.dto.internal;
+
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.event.entity.Schedule;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ScheduleInfo {
+    private Long scheduleId;
+    private Schedule schedule;
+    public static ScheduleInfo from(Event event){
+        return
+        ScheduleInfo.builder()
+                .scheduleId(event.getId())
+                .schedule(event.getSchedule())
+                .build();
+    }
+}

--- a/src/main/java/com/noljo/nolzo/event/repository/EventRepository.java
+++ b/src/main/java/com/noljo/nolzo/event/repository/EventRepository.java
@@ -1,12 +1,32 @@
 package com.noljo.nolzo.event.repository;
 
+import com.noljo.nolzo.event.dto.EventResponse;
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.entity.EventCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import java.util.List;
+
 import java.util.List;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findAllByEventCategory(EventCategory eventCategory);
+
+
+    @Query("""
+            select e
+            from Event e
+            where e.id in(
+                select min(e2.id)
+                from Event e2
+                where e2.eventCategory = :category
+                group by e2.title
+            )
+            """)
+    List<Event> findDistinctEventByCategory(@Param("category")EventCategory category);
+
+    List<Event> findAllByTitle(String title);
 }

--- a/src/main/java/com/noljo/nolzo/event/service/EventService.java
+++ b/src/main/java/com/noljo/nolzo/event/service/EventService.java
@@ -1,7 +1,9 @@
 package com.noljo.nolzo.event.service;
 
+import com.noljo.nolzo.event.dto.EventDetailResponse;
 import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.dto.EventResponse;
+import com.noljo.nolzo.event.dto.internal.ScheduleInfo;
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.entity.EventCategory;
 import com.noljo.nolzo.event.repository.EventRepository;
@@ -59,5 +61,22 @@ public class EventService {
         eventRepository.deleteById(id);
     }
 
-
+    public List<EventResponse> findDistinctEventByCategory(EventCategory category){
+        return eventRepository.findDistinctEventByCategory(category).stream()
+                .map(EventResponse::from)
+                .toList();
+    }
+    public EventDetailResponse findEventDetail(Long id){
+        Event event = getEvent(id);
+        List<Event> events = eventRepository.findAllByTitle(event.getTitle());
+        List<ScheduleInfo> scheduleInfos = events
+                .stream()
+                .map(ScheduleInfo::from)
+                .toList();
+        return
+                EventDetailResponse.from(scheduleInfos,event);
+    }
+//    public List<Event> findEventByTitle(String title){
+//        return eventRepository
+//    }
 }

--- a/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
@@ -1,13 +1,14 @@
 package com.noljo.nolzo.domain.event.service;
 
+import com.noljo.nolzo.event.dto.EventDetailResponse;
 import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.dto.EventResponse;
+import com.noljo.nolzo.event.dto.internal.ScheduleInfo;
 import com.noljo.nolzo.event.entity.EventCategory;
 import com.noljo.nolzo.event.service.EventService;
 import com.noljo.nolzo.support.annotation.ServiceTest;
 import com.noljo.nolzo.support.fixture.EventFixture;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
@@ -92,5 +93,32 @@ class EventServiceTest {
 
         Assertions.assertThat(id).isEqualTo(updatedResponse.getId());
         Assertions.assertThat("Hamlet").isEqualTo(updatedResponse.getTitle());
+    }
+
+    @Test
+    void 이벤트_중복없이_title기반_찾기(){
+        EventRequest dtoHam = EventFixture.햄릿dto();
+        EventResponse response1 = eventService.save(dtoHam);
+        EventRequest dtoHam2 = EventFixture.햄릿2dto();
+        EventResponse response2 = eventService.save(dtoHam2);
+
+        List<EventResponse> responses = eventService.findDistinctEventByCategory(EventCategory.CONCERT);
+
+        Assertions.assertThat(response1.getTitle()).isEqualTo(response2.getTitle());
+        Assertions.assertThat(responses.size()).isEqualTo(1);
+    }
+
+    @Test
+    void 동일_이벤트_회차조회(){
+        EventRequest dtoHam = EventFixture.햄릿dto();
+        EventResponse response2 = eventService.save(dtoHam);
+        EventRequest dtoHam2 = EventFixture.햄릿2dto();
+        EventResponse response3 = eventService.save(dtoHam2);
+
+        EventDetailResponse responseDetail = eventService.findEventDetail(response3.getId());
+        System.out.println(responseDetail.getTitle());
+        for(ScheduleInfo dto: responseDetail.getSchedules()){
+            System.out.println(dto.getSchedule().getShowDate());
+        }
     }
 }

--- a/src/test/java/com/noljo/nolzo/support/fixture/EventFixture.java
+++ b/src/test/java/com/noljo/nolzo/support/fixture/EventFixture.java
@@ -4,6 +4,8 @@ import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.entity.EventCategory;
 import java.time.LocalDate;
+import java.time.LocalTime;
+
 import com.noljo.nolzo.event.entity.Schedule;
 import lombok.Getter;
 
@@ -11,10 +13,13 @@ import lombok.Getter;
 public enum EventFixture {
     캣츠("Cats", "서울 예술의 전당", "세계적으로 유명한 뮤지컬, 고양이들의 이야기를 그린 작품입니다.",
             "https://example.com/cats.jpg", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 6, 30),
-            null, EventCategory.CONCERT, 180, 12, 5, 120),
+            new Schedule(LocalDate.of(2024, 5, 10), LocalTime.of(19, 30)), EventCategory.CONCERT, 180, 12, 5, 120),
     햄릿("Hamlet", "국립극장 해오름극장", "셰익스피어 4대 비극 중 하나인 '햄릿'의 현대적 재해석 공연입니다.",
             "https://example.com/hamlet.jpg", LocalDate.of(2025, 7, 1), LocalDate.of(2025, 7, 15),
-            null, EventCategory.CONCERT, 150, 15, 4, 80);
+            new Schedule(LocalDate.of(2024, 7, 10), LocalTime.of(18, 30)), EventCategory.CONCERT, 150, 15, 4, 80),
+    햄릿일정("Hamlet", "국립극장 해오름극장", "셰익스피어 4대 비극 중 하나인 '햄릿'의 현대적 재해석 공연.",
+               "https://example.com/hamlet.jpg", LocalDate.of(2025, 7, 1), LocalDate.of(2025, 7, 15),
+            new Schedule(LocalDate.of(2024, 5, 10), LocalTime.of(19, 30)), EventCategory.CONCERT, 150, 15, 4, 80);
 
     private String title;
     private String venue;
@@ -80,6 +85,20 @@ public enum EventFixture {
                 .eventCategory(햄릿.eventCategory)
                 .runtime(햄릿.runtime)
                 .ageLimit(햄릿.ageLimit)
+                .build();
+    }
+    public static EventRequest 햄릿2dto() {
+        return EventRequest.builder()
+                .title(햄릿일정.title)
+                .venue(햄릿일정.venue)
+                .description(햄릿일정.description)
+                .posterImageUrl(햄릿일정.posterImageUrl)
+                .startDate(햄릿일정.startDate)
+                .endDate(햄릿일정.endDate)
+                .schedule(햄릿일정.schedule)
+                .eventCategory(햄릿일정.eventCategory)
+                .runtime(햄릿일정.runtime)
+                .ageLimit(햄릿일정.ageLimit)
                 .build();
     }
 }


### PR DESCRIPTION
## 📌 개요
회차 정보를 Event 엔티티에 넣는 형식으로 진행할 때 기준으로
카테고리별로 이벤트를 확인하는 api와
상세정보에서 한 이벤트의 모든 회차를 확인할 수 있는 api를 구현

## 🛠️ 작업 내용
- [ ] 변경 사항 요약
- [ ] 주요 변경 사항 설명
- [ ] 관련 이슈 번호 (`#35`)

클라이언트에서 이벤트 카테고리를 선택했을 때 각 이벤트를 보여줄 수 있도록
카테고리별 이벤트를 하나씩 반환해주는 api (현 상태에서는 같은 공연도 다른ID를 지니게되기 때문에 따로 필요)
![image](https://github.com/user-attachments/assets/d54d4fcc-6d3d-4cfe-96c8-d26b62695598)

해당 이벤트를 클릭했을 때 요청하는 api는 해당 이벤트의 기본적인 정보+ 모든 회차정보를 모아서
List로 반환함으로서 프론트엔드에서는 위화감없이 사용할 수 있도록 처리할 수 있도록 구현했습니다.

해당 회차를 선택하고 예매페이지로 넘어갈 때 해당 회차에 해당하는 Event ID 가 필요하기 때문에
internaldto인 ScheduleInfo를 추가해 회차정보뿐 아니라 ID도 함께 전달될 수 있도록 구현했습니다.

## 📌 차후 계획 (Optional)
추후 리팩토링 기간에 엔티티를 분리해 새로 작성할 필요가 있어보입니다.


## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)
![image](https://github.com/user-attachments/assets/4de70f48-30cb-4a5d-b775-cf92d7b3cb8c)


Close #35 