### PR TITLE
[Feature] 예약 정보 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/noljo/nolzo/event/dto/ReservationEvent.java
+++ b/src/main/java/com/noljo/nolzo/event/dto/ReservationEvent.java
@@ -1,0 +1,33 @@
+package com.noljo.nolzo.event.dto;
+
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.reservation.entity.Reservation;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Builder
+@Getter
+public class ReservationEvent {
+
+    private Long id;
+    private String title;
+    private String venue;
+    private LocalDate date;
+    private LocalTime time;
+    private String image;
+
+    public static ReservationEvent from(Event event) {
+        return ReservationEvent.builder()
+                .id(event.getId())
+                .title(event.getTitle())
+                .venue(event.getVenue())
+                .date(event.getSchedule().getShowDate())
+                .time(event.getSchedule().getShowTime())
+                .image(event.getPosterImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
+++ b/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
@@ -1,0 +1,28 @@
+package com.noljo.nolzo.reservation.controller;
+
+import com.noljo.nolzo.auth.security.CustomUserDetails;
+import com.noljo.nolzo.reservation.dto.ReservationResponse;
+import com.noljo.nolzo.reservation.service.ReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @GetMapping
+    public ResponseEntity<List<ReservationResponse>> getReservations(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMemberId();
+        List<ReservationResponse> reservationDetails = reservationService.findReservations(memberId);
+        return ResponseEntity.ok(reservationDetails);
+    }
+}

--- a/src/main/java/com/noljo/nolzo/reservation/dto/ReservationDetail.java
+++ b/src/main/java/com/noljo/nolzo/reservation/dto/ReservationDetail.java
@@ -1,0 +1,38 @@
+package com.noljo.nolzo.reservation.dto;
+
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.reservation.entity.Reservation;
+import com.noljo.nolzo.reservation.entity.ReservationStatus;
+import com.noljo.nolzo.seat.entity.Seat;
+import com.noljo.nolzo.ticket.entity.Ticket;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Getter
+@Builder
+public class ReservationDetail {
+
+    private List<Seat> seats;
+    private String status;
+    private int totalPrice;
+    private String reservationNumber;
+
+    public static ReservationDetail from(Reservation reservation) {
+        List<Seat> reservedSeats = reservation.getTickets().stream()
+                .map(Ticket::getSeat)
+                .collect(toList());
+
+        return ReservationDetail.builder()
+                .seats(reservedSeats)
+                .status(reservation.getStatus().name())
+                .totalPrice(reservation.getTotalPrice())
+                .reservationNumber(reservation.getReservationNumber())
+                .build();
+    }
+}

--- a/src/main/java/com/noljo/nolzo/reservation/dto/ReservationResponse.java
+++ b/src/main/java/com/noljo/nolzo/reservation/dto/ReservationResponse.java
@@ -1,0 +1,21 @@
+package com.noljo.nolzo.reservation.dto;
+
+import com.noljo.nolzo.event.dto.ReservationEvent;
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.reservation.entity.Reservation;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReservationResponse {
+    private ReservationEvent event;
+    private ReservationDetail detail;
+
+    public static ReservationResponse of(Event event, Reservation reservation) {
+        return ReservationResponse.builder()
+                .event(ReservationEvent.from(event))
+                .detail(ReservationDetail.from(reservation))
+                .build();
+    }
+}

--- a/src/main/java/com/noljo/nolzo/reservation/entity/Reservation.java
+++ b/src/main/java/com/noljo/nolzo/reservation/entity/Reservation.java
@@ -4,6 +4,8 @@ import com.noljo.nolzo.global.BaseEntity;
 import com.noljo.nolzo.member.entity.Member;
 import com.noljo.nolzo.ticket.entity.Ticket;
 import jakarta.persistence.*;
+
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -26,7 +28,8 @@ public class Reservation extends BaseEntity {
 
     private int totalPrice;
 
-    private Long reservationNumber;
+    private String reservationNumber;
+
 
     @OneToMany(mappedBy = "reservation", cascade = CascadeType.PERSIST)
     private List<Ticket> tickets = new ArrayList<>();
@@ -36,7 +39,7 @@ public class Reservation extends BaseEntity {
     private Member member;
 
     @Builder
-    public Reservation(Long id, ReservationStatus status, int totalPrice, Long reservationNumber, Member member) {
+    public Reservation(Long id, ReservationStatus status, int totalPrice, String reservationNumber, Member member) {
         this.id = id;
         this.status = status;
         this.totalPrice = totalPrice;

--- a/src/main/java/com/noljo/nolzo/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/noljo/nolzo/reservation/repository/ReservationRepository.java
@@ -14,4 +14,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         return findById(id)
                 .orElseThrow(() -> new NotFoundException("not found")); // 에러코드 추후 통일화 필요
     }
+
+    List<Reservation> findReservationsByMemberId(Long memberId);
 }

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -1,0 +1,35 @@
+package com.noljo.nolzo.reservation.service;
+
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.event.repository.EventRepository;
+import com.noljo.nolzo.reservation.dto.ReservationDetail;
+import com.noljo.nolzo.reservation.dto.ReservationResponse;
+import com.noljo.nolzo.reservation.entity.Reservation;
+import com.noljo.nolzo.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final EventRepository eventRepository;
+
+    public List<ReservationResponse> findReservations(Long memberId) {
+
+        List<Reservation> reservationList = reservationRepository.findReservationsByMemberId(memberId);
+
+        return reservationList.stream()
+                .map(reservation ->{
+                    Event event = reservation.getTickets().get(0).getSeat().getEvent();
+                        return ReservationResponse.of(event,reservation);
+                        }
+                        )
+                .toList();
+    }
+}

--- a/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationServiceTest.java
@@ -1,0 +1,60 @@
+package com.noljo.nolzo.domain.reservation.service;
+
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.event.repository.EventRepository;
+import com.noljo.nolzo.member.entity.Member;
+import com.noljo.nolzo.member.repository.MemberRepository;
+import com.noljo.nolzo.reservation.dto.ReservationResponse;
+import com.noljo.nolzo.reservation.entity.Reservation;
+import com.noljo.nolzo.reservation.repository.ReservationRepository;
+import com.noljo.nolzo.reservation.service.ReservationService;
+import com.noljo.nolzo.seat.entity.Seat;
+import com.noljo.nolzo.seat.repository.SeatRepository;
+import com.noljo.nolzo.support.annotation.ServiceTest;
+import com.noljo.nolzo.support.fixture.*;
+import com.noljo.nolzo.ticket.repository.TicketRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ServiceTest
+public class ReservationServiceTest {
+
+    @Autowired
+    private ReservationService reservationService;
+    @Autowired
+    private EventRepository eventRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private SeatRepository seatRepository;
+    @Autowired
+    private ReservationRepository reservationRepository;
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Test
+    public void 전체_예약_조회() throws Exception {
+        //given
+        Event event1 = eventRepository.save(EventFixture.캣츠());
+        Event event2 = eventRepository.save(EventFixture.햄릿());
+        Member user = memberRepository.save(MemberFixture.회원());
+        Seat seat1 = seatRepository.save(SeatFixture.일반좌석(event1));
+        Seat seat2 = seatRepository.save(SeatFixture.일반좌석(event2));
+        Reservation reservation1 = reservationRepository.save(ReservationFixture.예약(user));
+        Reservation reservation2 = reservationRepository.save(ReservationFixture.예약2(user));
+        ticketRepository.save(TicketFixture.미사용티켓(reservation1,seat1));
+        ticketRepository.save(TicketFixture.미사용티켓(reservation2,seat2));
+
+        //when
+        List<ReservationResponse> reservations = reservationService.findReservations(user.getId());
+
+        //then
+        assertThat(reservations).hasSize(2);
+        assertThat(reservations.get(0).getEvent().getTitle()).isIn("Cats", "Hamlet");
+        assertThat(reservations.get(1).getDetail().getReservationNumber()).isIn("12313123L", "1322313123L");
+        }
+}

--- a/src/test/java/com/noljo/nolzo/support/fixture/EventFixture.java
+++ b/src/test/java/com/noljo/nolzo/support/fixture/EventFixture.java
@@ -4,6 +4,8 @@ import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.entity.EventCategory;
 import java.time.LocalDate;
+import java.time.LocalTime;
+
 import com.noljo.nolzo.event.entity.Schedule;
 import lombok.Getter;
 
@@ -11,10 +13,10 @@ import lombok.Getter;
 public enum EventFixture {
     캣츠("Cats", "서울 예술의 전당", "세계적으로 유명한 뮤지컬, 고양이들의 이야기를 그린 작품입니다.",
             "https://example.com/cats.jpg", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 6, 30),
-            null, EventCategory.CONCERT, 180, 12, 5, 120),
+            new Schedule(LocalDate.of(2024, 5, 10), LocalTime.of(19, 30)), EventCategory.CONCERT, 180, 12, 5, 120),
     햄릿("Hamlet", "국립극장 해오름극장", "셰익스피어 4대 비극 중 하나인 '햄릿'의 현대적 재해석 공연입니다.",
             "https://example.com/hamlet.jpg", LocalDate.of(2025, 7, 1), LocalDate.of(2025, 7, 15),
-            null, EventCategory.CONCERT, 150, 15, 4, 80);
+            new Schedule(LocalDate.of(2024, 7, 10), LocalTime.of(18, 30)), EventCategory.CONCERT, 150, 15, 4, 80);
 
     private String title;
     private String venue;
@@ -51,6 +53,11 @@ public enum EventFixture {
     public static Event 캣츠() {
         return new Event(null, 캣츠.title, 캣츠.venue, 캣츠.description, 캣츠.posterImageUrl,
                 캣츠.startDate, 캣츠.endDate, 캣츠.schedule, 캣츠.eventCategory, 캣츠.runtime, 캣츠.ageLimit, 캣츠.rating, 캣츠.reviewCount);
+    }
+
+    public static Event 햄릿() {
+        return new Event(null, 햄릿.title, 햄릿.venue, 햄릿.description, 햄릿.posterImageUrl,
+                햄릿.startDate, 햄릿.endDate, 햄릿.schedule, 햄릿.eventCategory, 햄릿.runtime, 햄릿.ageLimit, 햄릿.rating, 햄릿.reviewCount);
     }
 
     public static EventRequest 캣츠dto() {

--- a/src/test/java/com/noljo/nolzo/support/fixture/ReservationFixture.java
+++ b/src/test/java/com/noljo/nolzo/support/fixture/ReservationFixture.java
@@ -7,12 +7,13 @@ import lombok.Getter;
 
 @Getter
 public enum ReservationFixture {
-    예약(ReservationStatus.CONFIRMED, 15000, 12313123L); // 추후 총합가격 로직 추가시 수정
+    예약(ReservationStatus.CONFIRMED, 15000, "12313123L"), // 추후 총합가격 로직 추가시 수정
+    예약2(ReservationStatus.CONFIRMED, 15000, "1322313123L");
     private ReservationStatus reservationStatus;
     private int totalPrice;
-    private Long reservationNumber;
+    private String reservationNumber;
 
-    ReservationFixture(ReservationStatus reservationStatus, int totalPrice, Long reservationNumber) {
+    ReservationFixture(ReservationStatus reservationStatus, int totalPrice, String reservationNumber) {
         this.reservationStatus = reservationStatus;
         this.totalPrice = totalPrice;
         this.reservationNumber = reservationNumber;
@@ -20,5 +21,9 @@ public enum ReservationFixture {
 
     public static Reservation 예약(Member member) {
         return new Reservation(null, 예약.reservationStatus, 예약.totalPrice, 예약.reservationNumber, member);
+    }
+
+    public static Reservation 예약2(Member member) {
+        return new Reservation(null, 예약2.reservationStatus, 예약2.totalPrice, 예약2.reservationNumber, member);
     }
 }

--- a/src/test/java/com/noljo/nolzo/support/fixture/SeatFixture.java
+++ b/src/test/java/com/noljo/nolzo/support/fixture/SeatFixture.java
@@ -16,6 +16,7 @@ public enum SeatFixture {
     private SeatStatus status;
     private Event event;
 
+
     SeatFixture(String rowName, int seatNumber, String seatSection, String floor, int price, SeatStatus status) {
         this.rowName = rowName;
         this.seatNumber = seatNumber;


### PR DESCRIPTION
## 📌 개요
- 예약 정보에 대해서 전체 조회 목록을 조회하는 기능입니다

## 🛠️ 작업 내용
- 예약 정보 목록 api 구현 (`getReservations`)
- 예약 정보 목록 서비스(`findReservations`) 로직 작성 
- 예약 엔티티 관련 예약정보(`ReservationDetail`),공연 엔티티 관련 예약정보(`ReservationEvent`), 전체 예약정보 (`ReservationResponse`)dto 작성
- 예약 레포지토리 (`findReservationsByMemberId`)추가
- 테스트 코드 작성

## 📌 차후 계획 (Optional)
- 추가적

## 📌 테스트 케이스
- 기능 정상 동작 
- 새로운 의존성 추가 여부 없음
- 코드 스타일 및 컨벤션 준수 
- 기존 테스트 통과 

close #5 