### PR TITLE
[Feature] 관람완료 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
+++ b/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
@@ -34,9 +34,9 @@ public class ReservationController {
     }
 
     @GetMapping("/used")
-    public ResponseEntity<List<ReservationEventInfo>> getReservationUsed(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<List<ReservationEventInfo>> getTicketsUsed(@AuthenticationPrincipal CustomUserDetails userDetails) {
         Long memberId = userDetails.getMemberId();
-        List<ReservationEventInfo> reservationDetails = reservationService.findReservationsUsed(memberId);
+        List<ReservationEventInfo> reservationDetails = reservationService.findTicketsUsed(memberId);
         return ResponseEntity.ok(reservationDetails);
     }
 

--- a/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
+++ b/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
@@ -33,4 +33,11 @@ public class ReservationController {
         return ResponseEntity.ok(reservationDetails);
     }
 
+    @GetMapping("/used")
+    public ResponseEntity<List<ReservationEventInfo>> getReservationUsed(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMemberId();
+        List<ReservationEventInfo> reservationDetails = reservationService.findReservationsUsed(memberId);
+        return ResponseEntity.ok(reservationDetails);
+    }
+
 }

--- a/src/main/java/com/noljo/nolzo/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/noljo/nolzo/reservation/repository/ReservationRepository.java
@@ -3,6 +3,8 @@ package com.noljo.nolzo.reservation.repository;
 import com.noljo.nolzo.reservation.entity.Reservation;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.webjars.NotFoundException;
 
@@ -16,4 +18,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     }
 
     List<Reservation> findReservationsByMemberId(Long memberId);
+
+    @Query("SELECT r FROM Reservation r JOIN r.tickets t WHERE r.member.id = :memberId AND t.status = 'USED'")
+    List<Reservation> findTicketStatusUsedByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -71,7 +71,7 @@ public class ReservationService {
                 .toList();
     }
 
-    public List<ReservationEventInfo> findReservationsUsed(Long memberId) {
+    public List<ReservationEventInfo> findTicketsUsed(Long memberId) {
 
         List<Reservation> reservations = reservationRepository.findTicketStatusUsedByMemberId(memberId);
 

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -70,4 +70,17 @@ public class ReservationService {
                 )
                 .toList();
     }
+
+    public List<ReservationEventInfo> findReservationsUsed(Long memberId) {
+
+        List<Reservation> reservations = reservationRepository.findTicketStatusUsedByMemberId(memberId);
+
+        return reservations.stream()
+                .map(reservation -> {
+                            Event event = reservation.getTickets().get(0).getSeat().getEvent();
+                            return ReservationEventInfo.of(event, reservation);
+                        }
+                )
+                .toList();
+    }
 }


### PR DESCRIPTION
## 📌 개요
- 관람 완료된 공연에 대한 목록에 대해서 조회하는 기능입니다

## 🛠️ 작업 내용
- 관람 완료 목록 조회 API 구현 (`getTicketsUsed`)
- 관람 완료 서비스 로직(`findTicketsUsed`) 작성 
- 사용자 쿼리 메서드( `findTicketStatusUsedByMemberId`) 추가
-> 티켓상태가 `USED`인 티켓에 대한 예약만 조회


## 📌 차후 계획 (Optional)
- 관람 완료 리스트 조회 컨트롤러에 대한 단위 테스트 테스트 진행 예정
- fetch join을 활용한 성능 개선 리팩토링 예정


## 📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 여부 없음
- 코드 스타일 및 컨벤션 준수
- 기존 테스트 통과

Close #7 