### PR TITLE
[Refactor] 날짜 및 시간 선택 예외 사항 추가 리팩토링

### DIFF
--- a/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
+++ b/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @RestController
@@ -20,9 +22,11 @@ public class ReservationController {
     private final ReservationService reservationService;
 
     @PostMapping("/{eventId}")
-    public ResponseEntity<EventDateTimeResponse> chooseEventDateTime(@PathVariable Long eventId) {
+    public ResponseEntity<EventDateTimeResponse> chooseEventDateTime(@PathVariable Long eventId ,
+                                                                     @RequestParam LocalDate selectDate,
+                                                                     @RequestParam LocalTime selectTime) {
 
-        EventDateTimeResponse event = reservationService.readSelectedEventDateTime(eventId);
+        EventDateTimeResponse event = reservationService.readSelectedEventDateTime(eventId, selectDate, selectTime);
         return ResponseEntity.ok(event);
     }
   

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalTime;
 import java.util.List;
 
 @Transactional
@@ -50,11 +51,25 @@ public class ReservationService {
         return RESERVATION_NUMBER_PREFIX + yearSuffix + reservationId;
     }
 
-    public EventDateTimeResponse readSelectedEventDateTime(Long eventId) {
+    public EventDateTimeResponse readSelectedEventDateTime(Long eventId , LocalDate selectDate, LocalTime selectTime) {
 
-        Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 이벤트가 존재하지 않습니다"));
-        return EventDateTimeResponse.fromEvent(event);
+            Event event = eventRepository.findById(eventId)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 이벤트가 존재하지 않습니다"));
+
+            validateReadSelectedEventDateTime(event,selectDate,selectTime);
+
+            return EventDateTimeResponse.fromEvent(event);
+    }
+
+    private void validateReadSelectedEventDateTime(Event event ,LocalDate selectDate, LocalTime selectTime) {
+
+        if (!selectDate.equals(event.getSchedule().getShowDate())) {
+            throw new IllegalArgumentException("선택한 이벤트에 유효한 날짜가 존재하지 않습니다.");
+        }
+
+        if (!selectTime.equals(event.getSchedule().getShowTime())) {
+            throw new IllegalArgumentException("선택한 이벤트에 유효한 시간이 존재하지 않습니다.");
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationServiceTest.java
@@ -2,9 +2,9 @@ package com.noljo.nolzo.domain.reservation.service;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.repository.EventRepository;
+import com.noljo.nolzo.event.service.EventService;
 import com.noljo.nolzo.member.entity.Member;
 import com.noljo.nolzo.member.repository.MemberRepository;
 import com.noljo.nolzo.reservation.dto.EventDateTimeResponse;
@@ -21,9 +21,11 @@ import com.noljo.nolzo.ticket.repository.TicketRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -42,6 +44,8 @@ public class ReservationServiceTest {
     private ReservationRepository reservationRepository;
     @Autowired
     private TicketRepository ticketRepository;
+    @Autowired
+    private EventService eventService;
 
     @Test
     void 같은_좌석은_동시에_접근이_불가능하다() throws InterruptedException {
@@ -76,19 +80,53 @@ public class ReservationServiceTest {
     }
 
     @Test
-    public void 공연에_대한_날짜_시간_선택할_수_있다() throws Exception {
-        //given
-        Event event = eventRepository.save(EventFixture.캣츠());
+    public void 공연에_대한_날짜와_시간을_선택할_수_있다() {
+        // given
+        Event event = eventRepository.save(EventFixture.캣츠()); // showDate: 2025-12-01, showTime: 19:00
 
-        //when
-        EventDateTimeResponse response = reservationService.readSelectedEventDateTime(event.getId());
+        // when
+        EventDateTimeResponse response = reservationService.readSelectedEventDateTime(
+                event.getId(),
+                event.getSchedule().getShowDate(),
+                event.getSchedule().getShowTime()
+        );
 
-        //then
+        // then
         assertNotNull(response);
         assertEquals(event.getId(), response.getId());
-        assertNotNull(response.getShowdate());
-        assertNotNull(response.getShowTime());
+        assertEquals(event.getSchedule().getShowDate(), response.getShowdate());
+        assertEquals(event.getSchedule().getShowTime(), response.getShowTime());
     }
+
+    @Test
+    public void 공연에_대한_선택한_날짜가_없을_시_예외() {
+        // given
+        Event event = eventRepository.save(EventFixture.캣츠());
+
+        LocalDate wrongDate = event.getSchedule().getShowDate().plusDays(1);
+        LocalTime correctTime = event.getSchedule().getShowTime();
+
+        // when & then
+        assertThatThrownBy(() ->
+                reservationService.readSelectedEventDateTime(event.getId(), wrongDate, correctTime)
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void 공연에_대한_선택한_시간이_없을_시_예외() {
+        // given
+        Event event = eventRepository.save(EventFixture.캣츠());
+
+        LocalDate correctDate = event.getSchedule().getShowDate();
+        LocalTime wrongTime = event.getSchedule().getShowTime().plusHours(1);
+
+        // when & then
+
+        assertThatThrownBy(()->reservationService.readSelectedEventDateTime(event.getId(),correctDate,wrongTime))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+
 
     @Test
     public void 전체_예약_조회() throws Exception {


### PR DESCRIPTION
## 📌 개요
- 날짜 및 시간 선택에 대한 예외 사항을 추가 했습니다

## 🛠️ 작업 내용
- `chooseEventDateTime` API에 `@RequestParam`로 선택한 날짜와 시간을 받을 수 있도록 추가
- `validateReadSelectedEventDateTime`를 추가해 선택한 날짜 및 시간에 대한 예외 사항 추가
- 테스트 코드 변경

## 📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 여부 없음
- 코드 스타일 및 컨벤션 준수 
- 기존 테스트 통과 

Close #40 