### PR TITLE
[Feature] 예약 취소 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
+++ b/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
@@ -33,4 +33,11 @@ public class ReservationController {
         return ResponseEntity.ok(reservationDetails);
     }
 
+    @GetMapping("/cancel")
+    public ResponseEntity<List<ReservationEventInfo>> getCancelReservations(@AuthenticationPrincipal CustomUserDetails userDetails){
+        Long memberId = userDetails.getMemberId();
+        List<ReservationEventInfo> reservationDetails = reservationService.findCancelReservations(memberId);
+        return  ResponseEntity.ok(reservationDetails);
+    }
+
 }

--- a/src/main/java/com/noljo/nolzo/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/noljo/nolzo/reservation/repository/ReservationRepository.java
@@ -3,6 +3,8 @@ package com.noljo.nolzo.reservation.repository;
 import com.noljo.nolzo.reservation.entity.Reservation;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.webjars.NotFoundException;
 
@@ -16,4 +18,10 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     }
 
     List<Reservation> findReservationsByMemberId(Long memberId);
+
+    @Query("SELECT r FROM Reservation r JOIN r.tickets t WHERE r.member.id = :memberId AND t.status = 'CANCELED'")
+    List<Reservation> findTicketStatusCanceledByMemberId(@Param("memberId") Long memberId);
+
+    @Query("SELECT r FROM Reservation r WHERE r.member.id = :memberId AND r.status = 'CANCELED'")
+    List<Reservation> findReservationsStatusCanceledByMemberId(Long memberId);
 }

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -17,7 +17,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Transactional
 @Service
@@ -70,4 +73,23 @@ public class ReservationService {
                 )
                 .toList();
     }
+
+    public List<ReservationEventInfo> findCancelReservations(Long memberId) {
+
+        List<Reservation> cancelTickets = reservationRepository.findTicketStatusCanceledByMemberId(memberId);
+        List<Reservation> cancelReservations = reservationRepository.findReservationsStatusCanceledByMemberId(memberId);
+
+        Set<Reservation> cancelList = new HashSet<>();
+        cancelList.addAll(cancelTickets);
+        cancelList.addAll(cancelReservations);
+
+        return cancelList.stream()
+                .map(reservation -> {
+                            Event event = reservation.getTickets().get(0).getSeat().getEvent();
+                            return ReservationEventInfo.of(event, reservation);
+                        }
+                )
+                .toList();
+    }
 }
+


### PR DESCRIPTION
📌 개요
- 예약 및 티켓 취소에 대한 목록을 조회하는 기능입니다

🛠️ 작업 내용
- 예약 취소 목록 조회 API 구현 ('getCancelReservations')
- 예약 취소 서비스 로직(`findCancelReservations`) 작성
- 사용자 쿼리 메서드(`findTicketStatusCanceledByMemberId`,`findReservationsStatusCanceledByMemberId`) 추가
-> 예약이나 티켓의 상태가 `CANCELED`인 예약에 대해서 조회합니다

📌 차후 계획 (Optional)
- 예약 취소 리스트 조회 컨트롤러에 대한 단위 테스트 테스트 진행 예정

📌 테스트 케이스
- 기능 정상 동작 확인
- 새로운 의존성 추가 여부 없음
- 코드 스타일 및 컨벤션 준수
- 기존 테스트 통과

Close #46