### PR TITLE
[🚌 Issue] EventService 리팩토링

### DIFF
--- a/src/main/java/com/noljo/nolzo/event/controller/EventController.java
+++ b/src/main/java/com/noljo/nolzo/event/controller/EventController.java
@@ -3,6 +3,7 @@ package com.noljo.nolzo.event.controller;
 import com.noljo.nolzo.event.dto.EventDetailResponse;
 import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.dto.EventResponse;
+import com.noljo.nolzo.event.dto.EventUpdateRequest;
 import com.noljo.nolzo.event.entity.EventCategory;
 import com.noljo.nolzo.event.service.EventService;
 import jakarta.validation.Valid;
@@ -38,7 +39,7 @@ public class EventController {
     }
 
     @PostMapping("/update/{id}")
-    public ResponseEntity<EventResponse> updateEvent(@PathVariable Long id, @RequestBody @Valid EventRequest dto) {
+    public ResponseEntity<EventResponse> updateEvent(@PathVariable Long id, @RequestBody @Valid EventUpdateRequest dto) {
         return ResponseEntity.ok(eventService.update(id, dto));
     }
 

--- a/src/main/java/com/noljo/nolzo/event/dto/EventUpdateRequest.java
+++ b/src/main/java/com/noljo/nolzo/event/dto/EventUpdateRequest.java
@@ -1,0 +1,48 @@
+package com.noljo.nolzo.event.dto;
+
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.event.entity.Schedule;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventUpdateRequest {
+    @NotBlank(message = "제목 입력 필수")
+    private String title;
+
+    @NotBlank(message = "장소 입력 필수")
+    private String venue;
+
+    @NotBlank(message = "설명 입력 필수")
+    private String description;
+
+    @NotNull(message = "시작 입력 필수")
+    private LocalDate startDate;
+
+    @NotNull(message = "종료 입력 필수")
+    private LocalDate endDate;
+
+    @NotNull(message = "종료 입력 필수")
+    private Schedule schedule;
+
+    public Event toEntity(Event original) {
+        return Event.builder()
+                .id(original.getId())
+                .title(this.title)
+                .venue(this.venue)
+                .description(this.description)
+                .startDate(this.startDate)
+                .endDate(this.endDate)
+                .schedule(this.schedule)
+                .build();
+    }
+}

--- a/src/main/java/com/noljo/nolzo/event/entity/Event.java
+++ b/src/main/java/com/noljo/nolzo/event/entity/Event.java
@@ -1,6 +1,6 @@
 package com.noljo.nolzo.event.entity;
 
-import com.noljo.nolzo.payment.entity.Payment;
+import com.noljo.nolzo.event.dto.EventUpdateRequest;
 import com.noljo.nolzo.seat.entity.Seat;
 import jakarta.persistence.*;
 import java.util.ArrayList;
@@ -68,5 +68,13 @@ public class Event {
         this.rating = rating;
         this.reviewCount = reviewCount;
         this.seats = new ArrayList<>();
+    }
+    public void updateFrom(EventUpdateRequest dto) {
+        this.title         = dto.getTitle();
+        this.venue         = dto.getVenue();
+        this.description   = dto.getDescription();
+        this.startDate     = dto.getStartDate();
+        this.endDate       = dto.getEndDate();
+        this.schedule      = dto.getSchedule();
     }
 }

--- a/src/main/java/com/noljo/nolzo/event/service/EventService.java
+++ b/src/main/java/com/noljo/nolzo/event/service/EventService.java
@@ -3,6 +3,7 @@ package com.noljo.nolzo.event.service;
 import com.noljo.nolzo.event.dto.EventDetailResponse;
 import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.dto.EventResponse;
+import com.noljo.nolzo.event.dto.EventUpdateRequest;
 import com.noljo.nolzo.event.dto.internal.ScheduleInfo;
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.entity.EventCategory;
@@ -48,24 +49,18 @@ public class EventService {
         Event event = getEvent(id);
         return EventResponse.from(event);
     }
-    public EventResponse update(Long id, EventRequest dto) {
-        getEvent(id);
-        Event updated = dto.toEntity(id);
-        Event saved = eventRepository.save(updated);
-        return EventResponse.from(saved);
-    }
-
     public void delete(Long id) {
         getEvent(id);
-
         eventRepository.deleteById(id);
     }
 
+    @Transactional(readOnly = true)
     public List<EventResponse> findDistinctEventByCategory(EventCategory category){
         return eventRepository.findDistinctEventByCategory(category).stream()
                 .map(EventResponse::from)
                 .toList();
     }
+    @Transactional(readOnly = true)
     public EventDetailResponse findEventDetail(Long id){
         Event event = getEvent(id);
         List<Event> events = eventRepository.findAllByTitle(event.getTitle());
@@ -76,4 +71,11 @@ public class EventService {
         return
                 EventDetailResponse.from(scheduleInfos,event);
     }
+
+    public EventResponse update(Long id, EventUpdateRequest dto) {
+        Event original = getEvent(id);
+        original.updateFrom(dto);
+        return EventResponse.from(original);
+    }
+
 }

--- a/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
@@ -3,6 +3,7 @@ package com.noljo.nolzo.domain.event.service;
 import com.noljo.nolzo.event.dto.EventDetailResponse;
 import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.dto.EventResponse;
+import com.noljo.nolzo.event.dto.EventUpdateRequest;
 import com.noljo.nolzo.event.dto.internal.ScheduleInfo;
 import com.noljo.nolzo.event.entity.EventCategory;
 import com.noljo.nolzo.event.service.EventService;
@@ -85,14 +86,15 @@ class EventServiceTest {
     @Test
     void 이벤트를_갱신할_수_있다(){
         EventRequest dtoCats = EventFixture.캣츠dto();
-        EventRequest dtoHam = EventFixture.햄릿dto();
+        EventUpdateRequest dtoCats2 = EventFixture.캣츠2dto();
         EventResponse response = eventService.save(dtoCats);
         Long id = response.getId();
 
-        EventResponse updatedResponse = eventService.update(id,dtoHam);
+        Assertions.assertThat("Cats").isEqualTo(eventService.findById(id).getTitle());
+        EventResponse updatedResponse = eventService.update(id,dtoCats2);
 
         Assertions.assertThat(id).isEqualTo(updatedResponse.getId());
-        Assertions.assertThat("Hamlet").isEqualTo(updatedResponse.getTitle());
+        Assertions.assertThat("Cats2").isEqualTo(eventService.findById(id).getTitle());
     }
 
     @Test

--- a/src/test/java/com/noljo/nolzo/support/fixture/EventFixture.java
+++ b/src/test/java/com/noljo/nolzo/support/fixture/EventFixture.java
@@ -1,6 +1,7 @@
 package com.noljo.nolzo.support.fixture;
 
 import com.noljo.nolzo.event.dto.EventRequest;
+import com.noljo.nolzo.event.dto.EventUpdateRequest;
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.entity.EventCategory;
 import java.time.LocalDate;
@@ -14,6 +15,9 @@ public enum EventFixture {
     캣츠("Cats", "서울 예술의 전당", "세계적으로 유명한 뮤지컬, 고양이들의 이야기를 그린 작품입니다.",
             "https://example.com/cats.jpg", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 6, 30),
             new Schedule(LocalDate.of(2024, 5, 10), LocalTime.of(19, 30)), EventCategory.CONCERT, 180, 12, 5, 120),
+    캣츠2("Cats2", "서울 예술의 전당", "세계적으로 유명한 뮤지컬, 고양이들의 이야기를 그린 작품입니다.",
+            "https://example.com/cats.jpg", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 6, 30),
+            new Schedule(LocalDate.of(2024, 5, 11), LocalTime.of(19, 30)), EventCategory.CONCERT, 180, 12, 5, 120),
     햄릿("Hamlet", "국립극장 해오름극장", "셰익스피어 4대 비극 중 하나인 '햄릿'의 현대적 재해석 공연입니다.",
             "https://example.com/hamlet.jpg", LocalDate.of(2025, 7, 1), LocalDate.of(2025, 7, 15),
             new Schedule(LocalDate.of(2024, 7, 10), LocalTime.of(18, 30)), EventCategory.CONCERT, 150, 15, 4, 80),
@@ -75,6 +79,16 @@ public enum EventFixture {
                 .eventCategory(캣츠.eventCategory)
                 .runtime(캣츠.runtime)
                 .ageLimit(캣츠.ageLimit)
+                .build();
+    }
+    public static EventUpdateRequest 캣츠2dto() {
+        return EventUpdateRequest.builder()
+                .title(캣츠2.title)
+                .venue(캣츠2.venue)
+                .description(캣츠2.description)
+                .startDate(캣츠2.startDate)
+                .endDate(캣츠2.endDate)
+                .schedule(캣츠2.schedule)
                 .build();
     }
 


### PR DESCRIPTION
## 📌 개요

EventService의 update처리방식 개선 및 예외처리 리팩토링 진행


## 🛠️ 작업 내용
'EventUpdateRequest' dto 추가
Event 엔티티에 업데이트 메서드 추가
둘을 활용해서 EventService의 업데이트 방식 변경.


## 📌 차후 계획 (Optional)

Schedule 엔티티 분리 시 리팩토링 필요


## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인


---

close #37 