### PR TITLE
[Feature] 조회수 기반 상위 10개 이벤트 조회 기능 구현

### DIFF
--- a/src/main/java/com/noljo/nolzo/event/controller/EventController.java
+++ b/src/main/java/com/noljo/nolzo/event/controller/EventController.java
@@ -47,11 +47,6 @@ public class EventController {
         return ResponseEntity.ok(eventService.getTop10ByCategory(category));
     }
 
-    @GetMapping("/popular")
-    public ResponseEntity<List<EventResponse>> getTop6PopularEvents() {
-        return ResponseEntity.ok(eventService.getTop6PopularEvents());
-    }
-
     @PostMapping("/update/{id}")
     public ResponseEntity<EventResponse> updateEvent(@PathVariable Long id, @RequestBody @Valid EventUpdateRequest dto) {
         return ResponseEntity.ok(eventService.update(id, dto));

--- a/src/main/java/com/noljo/nolzo/event/controller/EventController.java
+++ b/src/main/java/com/noljo/nolzo/event/controller/EventController.java
@@ -47,6 +47,11 @@ public class EventController {
         return ResponseEntity.ok(eventService.getTop10ByCategory(category));
     }
 
+    @GetMapping("/popular")
+    public ResponseEntity<List<EventResponse>> getTop6PopularEvents() {
+        return ResponseEntity.ok(eventService.getTop6PopularEvents());
+    }
+
     @PostMapping("/update/{id}")
     public ResponseEntity<EventResponse> updateEvent(@PathVariable Long id, @RequestBody @Valid EventUpdateRequest dto) {
         return ResponseEntity.ok(eventService.update(id, dto));

--- a/src/main/java/com/noljo/nolzo/event/controller/EventController.java
+++ b/src/main/java/com/noljo/nolzo/event/controller/EventController.java
@@ -42,6 +42,11 @@ public class EventController {
         return ResponseEntity.ok(eventService.searchEventList(search));
     }
 
+    @GetMapping("/rankings")
+    public ResponseEntity<List<EventResponse>> getRankingsByCategory(@RequestParam EventCategory category) {
+        return ResponseEntity.ok(eventService.getTop10ByCategory(category));
+    }
+
     @PostMapping("/update/{id}")
     public ResponseEntity<EventResponse> updateEvent(@PathVariable Long id, @RequestBody @Valid EventUpdateRequest dto) {
         return ResponseEntity.ok(eventService.update(id, dto));

--- a/src/main/java/com/noljo/nolzo/event/dto/EventResponse.java
+++ b/src/main/java/com/noljo/nolzo/event/dto/EventResponse.java
@@ -26,6 +26,7 @@ public class EventResponse {
     private int ageLimit;
     private int rating;
     private int reviewCount;
+    private long viewCount;
 
     public static EventResponse from(Event event) {
         List<ScheduleResponse> schedules = event.getSchedules().stream()
@@ -46,6 +47,7 @@ public class EventResponse {
                 .rating(event.getRating())
                 .reviewCount(event.getReviewCount())
                 .schedule(schedules)
+                .viewCount(event.getViewCount())
                 .build();
     }
 }

--- a/src/main/java/com/noljo/nolzo/event/entity/Event.java
+++ b/src/main/java/com/noljo/nolzo/event/entity/Event.java
@@ -47,6 +47,9 @@ public class Event extends BaseEntity {
 
     private int reviewCount;
 
+    @Column(nullable = false)
+    private long viewCount = 0;
+
     @OneToMany(mappedBy = "event", cascade = CascadeType.ALL)
     private List<Schedule> schedules = new ArrayList<>();
 
@@ -72,6 +75,11 @@ public class Event extends BaseEntity {
         schedules.add(schedule);
         schedule.setEvent(this);
     }
+
+    public void addViewCount() {
+        this.viewCount++;
+    }
+
     public void updateFrom(EventUpdateRequest dto) {
         this.title         = dto.getTitle();
         this.venue         = dto.getVenue();

--- a/src/main/java/com/noljo/nolzo/event/entity/EventCategory.java
+++ b/src/main/java/com/noljo/nolzo/event/entity/EventCategory.java
@@ -1,7 +1,7 @@
 package com.noljo.nolzo.event.entity;
 
 public enum EventCategory {
-    CONCERT,
     MUSICAL,
+    CONCERT,
     PLAY;
 }

--- a/src/main/java/com/noljo/nolzo/event/repository/EventRepository.java
+++ b/src/main/java/com/noljo/nolzo/event/repository/EventRepository.java
@@ -12,7 +12,6 @@ import java.util.List;
 public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findAllByEventCategory(EventCategory eventCategory);
 
-
     @Query("""
         SELECT e FROM Event e
         WHERE (:keyword = 'all' OR e.title LIKE CONCAT('%', :keyword, '%'))
@@ -24,4 +23,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
         ORDER BY e.title ASC
     """)
     List<Event> findOnePerTitle(@Param("keyword") String keyword);
+
+    List<Event> findTop10ByEventCategoryOrderByViewCountDesc(EventCategory eventCategory);
+
+    List<Event> findTop6ByOrderByViewCountDesc();
 }

--- a/src/main/java/com/noljo/nolzo/event/repository/EventRepository.java
+++ b/src/main/java/com/noljo/nolzo/event/repository/EventRepository.java
@@ -25,6 +25,4 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findOnePerTitle(@Param("keyword") String keyword);
 
     List<Event> findTop10ByEventCategoryOrderByViewCountDesc(EventCategory eventCategory);
-
-    List<Event> findTop6ByOrderByViewCountDesc();
 }

--- a/src/main/java/com/noljo/nolzo/event/service/EventService.java
+++ b/src/main/java/com/noljo/nolzo/event/service/EventService.java
@@ -41,11 +41,13 @@ public class EventService {
         return EventResponse.from(saved);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public EventResponse findById(Long id) {
         Event event = getEvent(id);
+        event.addViewCount();
         return EventResponse.from(event);
     }
+
     public void delete(Long id) {
         getEvent(id);
         eventRepository.deleteById(id);

--- a/src/main/java/com/noljo/nolzo/event/service/EventService.java
+++ b/src/main/java/com/noljo/nolzo/event/service/EventService.java
@@ -53,7 +53,6 @@ public class EventService {
         eventRepository.deleteById(id);
     }
 
-
     public List<EventResponse> searchEventList(String search) {
         List<Event> events = eventRepository.findOnePerTitle(search);
         return events.stream()
@@ -75,6 +74,7 @@ public class EventService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public List<EventResponse> getTop6PopularEvents() {
         List<Event> popularEventList = eventRepository.findTop6ByOrderByViewCountDesc();
         return popularEventList.stream()

--- a/src/main/java/com/noljo/nolzo/event/service/EventService.java
+++ b/src/main/java/com/noljo/nolzo/event/service/EventService.java
@@ -66,4 +66,19 @@ public class EventService {
         original.updateFrom(dto);
         return EventResponse.from(original);
     }
+
+    @Transactional(readOnly = true)
+    public List<EventResponse> getTop10ByCategory(EventCategory category) {
+        List<Event> eventList = eventRepository.findTop10ByEventCategoryOrderByViewCountDesc(category);
+        return eventList.stream()
+                .map(EventResponse::from)
+                .toList();
+    }
+
+    public List<EventResponse> getTop6PopularEvents() {
+        List<Event> popularEventList = eventRepository.findTop6ByOrderByViewCountDesc();
+        return popularEventList.stream()
+                .map(EventResponse::from)
+                .toList();
+    }
 }

--- a/src/main/java/com/noljo/nolzo/event/service/EventService.java
+++ b/src/main/java/com/noljo/nolzo/event/service/EventService.java
@@ -73,12 +73,4 @@ public class EventService {
                 .map(EventResponse::from)
                 .toList();
     }
-
-    @Transactional(readOnly = true)
-    public List<EventResponse> getTop6PopularEvents() {
-        List<Event> popularEventList = eventRepository.findTop6ByOrderByViewCountDesc();
-        return popularEventList.stream()
-                .map(EventResponse::from)
-                .toList();
-    }
 }

--- a/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
@@ -119,9 +119,29 @@ class EventServiceTest {
 
         event = eventRepository.save(event);
 
-        EventResponse response = eventService.findById(event.getId()); // 1회 조회
+        eventService.findById(event.getId());
         Event updatedEvent = eventRepository.findById(event.getId()).orElseThrow();
 
         Assertions.assertThat(updatedEvent.getViewCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 카테고리별로_상위_10개의_이벤트를_조회할_수_있다() {
+        Event cats   = eventRepository.save(EventFixture.캣츠());
+        Event hamlet = eventRepository.save(EventFixture.햄릿());
+
+        for (int i = 0; i < 5; i++)  cats.addViewCount();
+        for (int i = 0; i < 10; i++) hamlet.addViewCount();
+
+        eventRepository.save(cats);
+        eventRepository.save(hamlet);
+
+        List<EventResponse> result =
+                eventService.getTop10ByCategory(EventCategory.CONCERT);
+
+        Assertions.assertThat(result).hasSize(2);
+        Assertions.assertThat(result.get(0).getId()).isEqualTo(hamlet.getId());
+        Assertions.assertThat(result.get(1).getId()).isEqualTo(cats.getId());
+        Assertions.assertThat(result.get(0).getViewCount()).isGreaterThan(result.get(1).getViewCount());
     }
 }

--- a/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
@@ -3,13 +3,16 @@ package com.noljo.nolzo.domain.event.service;
 import com.noljo.nolzo.event.dto.EventRequest;
 import com.noljo.nolzo.event.dto.EventResponse;
 import com.noljo.nolzo.event.dto.EventUpdateRequest;
+import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.entity.EventCategory;
+import com.noljo.nolzo.event.repository.EventRepository;
 import com.noljo.nolzo.event.service.EventService;
 import com.noljo.nolzo.support.annotation.ServiceTest;
 import com.noljo.nolzo.support.fixture.EventFixture;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import java.time.LocalDate;
 import java.util.List;
 
 @ServiceTest
@@ -17,6 +20,9 @@ class EventServiceTest {
 
     @Autowired
     EventService eventService;
+
+    @Autowired
+    EventRepository eventRepository;
 
     @Test
     void 이벤트를_저장할_수_있다() {
@@ -27,14 +33,14 @@ class EventServiceTest {
     }
 
     @Test
-    void 이벤트를_조회할_수_있다(){
+    void 이벤트를_조회할_수_있다() {
         EventRequest dto = EventFixture.캣츠dto();
         EventResponse response = eventService.save(dto);
         Assertions.assertThat(response.getId()).isEqualTo(eventService.findAll().get(0).getId());
     }
 
     @Test
-    void 개별_이벤트를_조회할_수_있다(){
+    void 개별_이벤트를_조회할_수_있다() {
 
         EventRequest dto = EventFixture.캣츠dto();
 
@@ -71,31 +77,51 @@ class EventServiceTest {
 
 
     @Test
-    void 이벤트를_삭제할_수_있다(){
+    void 이벤트를_삭제할_수_있다() {
         EventRequest dto = EventFixture.캣츠dto();
         EventResponse response = eventService.save(dto);
         Long id = response.getId();
 
         eventService.delete(id);
 
-        Assertions.assertThatThrownBy(()->eventService.findById(id)).isInstanceOf(IllegalArgumentException.class);
+        Assertions.assertThatThrownBy(() -> eventService.findById(id)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void 이벤트를_갱신할_수_있다(){
+    void 이벤트를_갱신할_수_있다() {
         EventRequest dtoCats = EventFixture.캣츠dto();
         EventUpdateRequest dtoCats2 = EventFixture.캣츠2dto();
         EventResponse response = eventService.save(dtoCats);
         Long id = response.getId();
 
         Assertions.assertThat("Cats").isEqualTo(eventService.findById(id).getTitle());
-        EventResponse updatedResponse = eventService.update(id,dtoCats2);
+        EventResponse updatedResponse = eventService.update(id, dtoCats2);
 
         Assertions.assertThat(id).isEqualTo(updatedResponse.getId());
         Assertions.assertThat("Cats2").isEqualTo(eventService.findById(id).getTitle());
     }
 
+    @Test
+    void 조회하면_viewCount가_1_증가한다() {
+        Event event = Event.builder()
+                .title("뮤지컬 캣츠")
+                .venue("세종문화회관")
+                .description("전설의 고양이")
+                .posterImageUrl("http://image.url")
+                .startDate(LocalDate.of(2025, 7, 1))
+                .endDate(LocalDate.of(2025, 7, 10))
+                .eventCategory(EventCategory.MUSICAL)
+                .runtime(120)
+                .ageLimit(12)
+                .rating(5)
+                .reviewCount(10)
+                .build();
 
+        event = eventRepository.save(event);
 
+        EventResponse response = eventService.findById(event.getId()); // 1회 조회
+        Event updatedEvent = eventRepository.findById(event.getId()).orElseThrow();
 
+        Assertions.assertThat(updatedEvent.getViewCount()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
## 📌 개요
사용자가 이벤트 상세 페이지에 진입할 때마다 해당 이벤트의 조회수를 1씩 증가시키고,
조회수 기준 상위 10개의 이벤트를 조회할 수 있는 기능을 구현했습니다.

## 🛠️ 작업 내용
- [x] Event 엔터티에 viewCount 필드 및 증가 메서드(addViewCount) 추가
- [x] 조회 시 viewCount 1 증가 처리
- [x] 카테고리별 상위 10개 이벤트 조회 기능 구현
- [x] 전체 이벤트에서 상위 6개 이벤트 조회 기능 구현
- [x] 해당 기능에 대한 단위 테스트 코드 작성
- [x] 관련 이슈 번호 (`#56`)

## 📌 테스트 케이스
<img width="489" alt="상위 6개, 10개 랭킹 조회" src="https://github.com/user-attachments/assets/566eb247-6ecc-4b05-a270-7649a33ea259" />

- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.