### PR TITLE
[Fix] EventResponse 필드 변수명 수정

### DIFF
--- a/src/main/java/com/noljo/nolzo/event/dto/EventResponse.java
+++ b/src/main/java/com/noljo/nolzo/event/dto/EventResponse.java
@@ -21,7 +21,7 @@ public class EventResponse {
     private String posterImageUrl;
     private LocalDate startDate;
     private LocalDate endDate;
-    private List<ScheduleResponse> schedule;
+    private List<ScheduleResponse> schedules;
     private EventCategory eventCategory;
     private int runtime;
     private int ageLimit;
@@ -49,7 +49,7 @@ public class EventResponse {
                 .ageLimit(event.getAgeLimit())
                 .rating(event.getRating())
                 .reviewCount(event.getReviewCount())
-                .schedule(schedules)
+                .schedules(schedules)
                 .viewCount(event.getViewCount())
                 .reservationStart(event.getReservationStart())
                 .reservationEnd(event.getReservationEnd())


### PR DESCRIPTION
## 📌 개요
- API 호출 시 JSON 응답에 `schedule` 필드명이 다른 곳과 중복되어 충돌이 발생합니다.
- 해당 필드를 단일 스케줄이 아닌 여러 개의 스케줄을 담는 컬렉션임을 명확히 하기 위해 `schedule` → `schedules`로 복수형으로 변경합니다.

## 🛠️ 작업 내용
- [ ] 변경 사항 요약
- [ ] 주요 변경 사항 설명
- [ ] 관련 이슈 번호 (`#85`)
### (소제목)

## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

#Close 85