### PR TITLE
fix : 엔티티 누락 매핑 문제 해결에 따른 테스트 코드 변경

### DIFF
--- a/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationServiceTest.java
@@ -77,23 +77,27 @@ public class ReservationServiceTest {
     @Test
     void 공연에_대한_날짜와_시간을_선택할_수_있다() {
         Event event = eventRepository.save(EventFixture.캣츠());
-        LocalDate showDate = event.getSchedules().get(0).getShowDate();
-        LocalTime showTime = event.getSchedules().get(0).getShowTime();
+        Schedule schedule = scheduleRepository.save(ScheduleFixture.공연_스케쥴(event));
+        event.addSchedule(schedule);
 
-        EventDateTimeResponse response = reservationService.readSelectedEventDateTime(event.getId(), showDate,
-                showTime);
+
+        EventDateTimeResponse response = reservationService.readSelectedEventDateTime(event.getId(), schedule.getShowDate(),
+                schedule.getShowTime());
 
         assertNotNull(response);
         assertEquals(event.getId(), response.getId());
-        assertEquals(showDate, response.getShowDate());
-        assertEquals(showTime, response.getShowTime());
+        assertEquals(schedule.getShowDate(), response.getShowDate());
+        assertEquals(schedule.getShowTime(), response.getShowTime());
     }
 
     @Test
     void 공연에_대한_선택한_날짜가_없을_시_예외() {
         Event event = eventRepository.save(EventFixture.캣츠());
-        LocalDate wrongDate = event.getSchedules().get(0).getShowDate().plusDays(1);
-        LocalTime correctTime = event.getSchedules().get(0).getShowTime();
+        Schedule schedule = scheduleRepository.save(ScheduleFixture.공연_스케쥴(event));
+        event.addSchedule(schedule);
+
+        LocalDate wrongDate = schedule.getShowDate().plusDays(1);
+        LocalTime correctTime = schedule.getShowTime();
 
         assertThatThrownBy(() -> reservationService.readSelectedEventDateTime(event.getId(), wrongDate, correctTime))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -102,8 +106,11 @@ public class ReservationServiceTest {
     @Test
     void 공연에_대한_선택한_시간이_없을_시_예외() {
         Event event = eventRepository.save(EventFixture.캣츠());
-        LocalDate correctDate = event.getSchedules().get(0).getShowDate();
-        LocalTime wrongTime = event.getSchedules().get(0).getShowTime().plusHours(1);
+        Schedule schedule = scheduleRepository.save(ScheduleFixture.공연_스케쥴(event));
+        event.addSchedule(schedule);
+
+        LocalDate correctDate = schedule.getShowDate();
+        LocalTime wrongTime = schedule.getShowTime().plusHours(1);
 
         assertThatThrownBy(() -> reservationService.readSelectedEventDateTime(event.getId(), correctDate, wrongTime))
                 .isInstanceOf(IllegalArgumentException.class);


### PR DESCRIPTION
## 📌 개요
- 엔티티 매핑 중 누락된 매핑이 있어 변경 후 테스트 코드 변경

## 🛠️ 작업 내용
- [x] `공연에_대한_날짜와_시간을_선택할_수_있다` 테스트 코드 변경
- [x] `공연에_대한_선택한_날짜가_없을_시_예외` 테스트 코드 변경
- [x] `공연에_대한_선택한_시간이_없을_시_예외` 테스트 코드 변경

## 📌 차후 계획 (Optional)
- API 연동 후 클라이언트-서버 간 에러 메시지 정리


## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

close #87 