### PR TITLE
[Fix] JPA Lazy 로딩과 JSON 직렬화 순환참조 문제 해결

### DIFF
--- a/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
+++ b/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
@@ -76,8 +76,9 @@ public class ReservationController {
 
     @GetMapping("/details/{reservationId}")
     public ResponseEntity<ReservationEventInfo> getReservationDetails(
-            @AuthenticationPrincipal(expression = "memberId") Long memberId) {
-        ReservationEventInfo reservationDetails = reservationService.findReservationDetails(memberId);
+            @AuthenticationPrincipal(expression = "memberId") Long memberId,
+            @PathVariable Long reservationId) {
+        ReservationEventInfo reservationDetails = reservationService.findReservationDetails(memberId, reservationId);
         return ResponseEntity.ok(reservationDetails);
 
     }

--- a/src/main/java/com/noljo/nolzo/reservation/dto/ReservationDetail.java
+++ b/src/main/java/com/noljo/nolzo/reservation/dto/ReservationDetail.java
@@ -3,6 +3,7 @@ package com.noljo.nolzo.reservation.dto;
 import com.noljo.nolzo.payment.entity.Payment;
 import com.noljo.nolzo.payment.entity.PaymentMethod;
 import com.noljo.nolzo.reservation.entity.Reservation;
+import com.noljo.nolzo.seat.dto.SeatResponse;
 import com.noljo.nolzo.seat.entity.Seat;
 import com.noljo.nolzo.ticket.entity.Ticket;
 import lombok.Builder;
@@ -19,7 +20,7 @@ import static java.util.stream.Collectors.toList;
 public class ReservationDetail {
 
     private Long id;
-    private List<Seat> seats;
+    private List<SeatResponse> seats;
     private String status;
     private int totalPrice;
     private String reservationNumber;
@@ -28,11 +29,13 @@ public class ReservationDetail {
 
 
     public static ReservationDetail from(Reservation reservation) {
-        List<Seat> reservedSeats = reservation.getTickets().stream()
+        List<SeatResponse> reservedSeats = reservation.getTickets().stream()
                 .map(Ticket::getSeat)
+                .map(SeatResponse::from)
                 .collect(toList());
 
         return ReservationDetail.builder()
+                .id(reservation.getId())
                 .seats(reservedSeats)
                 .status(reservation.getStatus().name())
                 .totalPrice(reservation.getTotalPrice())
@@ -42,8 +45,9 @@ public class ReservationDetail {
     }
 
     public static ReservationDetail fromDetails(Reservation reservation, Payment payment) {
-        List<Seat> reservedSeats = reservation.getTickets().stream()
+        List<SeatResponse> reservedSeats = reservation.getTickets().stream()
                 .map(Ticket::getSeat)
+                .map(SeatResponse::from)
                 .collect(toList());
 
         return ReservationDetail.builder()

--- a/src/main/java/com/noljo/nolzo/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/noljo/nolzo/reservation/repository/ReservationRepository.java
@@ -67,7 +67,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     JOIN FETCH t.seat s
     JOIN FETCH s.schedule sch
     JOIN FETCH sch.event e
-    WHERE r.member.id = :memberId
+    WHERE r.member.id = :memberId AND r.id = :reservationId
 """)
-    Reservation findReservationDetailsByMemberId(@Param("memberId") Long memberId);
+    Reservation findReservationDetailsByMemberId(@Param("memberId") Long memberId, @Param("reservationId") Long reservationId);
 }

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -119,8 +119,8 @@ public class ReservationService {
     }
 
     @Transactional(readOnly = true)
-    public ReservationEventInfo findReservationDetails(Long memberId) {
-        Reservation reservation = reservationRepository.findReservationDetailsByMemberId(memberId);
+    public ReservationEventInfo findReservationDetails(Long memberId, Long reservationId) {
+        Reservation reservation = reservationRepository.findReservationDetailsByMemberId(memberId,reservationId);
         Payment payment = paymentRepository.findPaymentByMemberIdAndReservationId(memberId, reservation.getId());
 
         Event event = reservation.getTickets().stream()


### PR DESCRIPTION
## 📌 개요
- JPA의 Lazy 로딩으로 인한 Jackson JSON 직렬화 오류(무한 참조) 해결을 위해 DTO 구조를 수정했습니다. 추가적으로 누락된 코드 추가했습니다

## 🛠️ 작업 내용
- DTO (SeatResponse, ReservationDetail, ReservationEventInfo) 를 통해 Entity 직접 노출 제거
- 누락된 코드 발견 및 추가

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

close #96 