### PR TITLE
[Feature] 관람 시작 시간 30분 후 티켓 관람완료 상태변경 기능 구현

### DIFF
--- a/src/main/java/com/noljo/nolzo/global/config/SchedulerConfig.java
+++ b/src/main/java/com/noljo/nolzo/global/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.noljo.nolzo.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/noljo/nolzo/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/noljo/nolzo/ticket/repository/TicketRepository.java
@@ -1,11 +1,28 @@
 package com.noljo.nolzo.ticket.repository;
 
 import com.noljo.nolzo.ticket.entity.Ticket;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
     List<Ticket> findByReservationIdIn(List<Long> reservationIdList);
+
+    @Modifying
+    @Query("""
+    UPDATE Ticket t
+    SET t.status = 'USED'
+    WHERE t.status != 'USED'
+    AND t.seat.schedule.showDate = :targetDate
+    AND t.seat.schedule.showTime <= :targetTime
+""")
+    void updateExpiredTickets(@Param("targetDate") LocalDate targetDate,
+                              @Param("targetTime") LocalTime targetTime);
 }

--- a/src/main/java/com/noljo/nolzo/ticket/scheduler/TickerScheduler.java
+++ b/src/main/java/com/noljo/nolzo/ticket/scheduler/TickerScheduler.java
@@ -14,7 +14,7 @@ public class TickerScheduler {
 
     private final TicketService ticketService;
 
-    @Scheduled(fixedRate = 1800000 )
+    @Scheduled(fixedRate = 1800000)
     public void changeUsed() {
         LocalDate today = LocalDate.now();
         LocalTime currentTime = LocalTime.now();

--- a/src/main/java/com/noljo/nolzo/ticket/scheduler/TickerScheduler.java
+++ b/src/main/java/com/noljo/nolzo/ticket/scheduler/TickerScheduler.java
@@ -1,0 +1,24 @@
+package com.noljo.nolzo.ticket.scheduler;
+
+import com.noljo.nolzo.ticket.service.TicketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Component
+@RequiredArgsConstructor
+public class TickerScheduler {
+
+    private final TicketService ticketService;
+
+    @Scheduled(fixedRate = 1800 )
+    public void changeUsed() {
+        LocalDate today = LocalDate.now();
+        LocalTime currentTime = LocalTime.now();
+
+        ticketService.updateTicketStatusUsed(today,currentTime);
+    }
+}

--- a/src/main/java/com/noljo/nolzo/ticket/scheduler/TickerScheduler.java
+++ b/src/main/java/com/noljo/nolzo/ticket/scheduler/TickerScheduler.java
@@ -14,7 +14,7 @@ public class TickerScheduler {
 
     private final TicketService ticketService;
 
-    @Scheduled(fixedRate = 1800 )
+    @Scheduled(fixedRate = 1800000 )
     public void changeUsed() {
         LocalDate today = LocalDate.now();
         LocalTime currentTime = LocalTime.now();

--- a/src/main/java/com/noljo/nolzo/ticket/service/TicketService.java
+++ b/src/main/java/com/noljo/nolzo/ticket/service/TicketService.java
@@ -49,6 +49,10 @@ public class TicketService {
         return TicketResponse.from(ticket);
     }
 
+    public void updateTicketStatusUsed(LocalDate targetDate, LocalTime targetTime) {
+        ticketRepository.updateExpiredTickets(targetDate, targetTime);
+    }
+
     private List<Long> findReservationIdListByMemberId(Member member) {
         return reservationRepository.findByMemberId(member.getId())
                 .stream()
@@ -61,7 +65,4 @@ public class TicketService {
                 .orElseThrow(() -> new IllegalArgumentException("Ticket Not Found"));
     }
 
-    public void updateTicketStatusUsed(LocalDate targetDate, LocalTime targetTime) {
-        ticketRepository.updateExpiredTickets(targetDate, targetTime);
-    }
 }

--- a/src/main/java/com/noljo/nolzo/ticket/service/TicketService.java
+++ b/src/main/java/com/noljo/nolzo/ticket/service/TicketService.java
@@ -9,6 +9,9 @@ import com.noljo.nolzo.ticket.dto.TicketResponse;
 import com.noljo.nolzo.ticket.entity.Ticket;
 import com.noljo.nolzo.ticket.entity.TicketStatus;
 import com.noljo.nolzo.ticket.repository.TicketRepository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -56,5 +59,9 @@ public class TicketService {
     private Ticket findTicketById(Long ticketId) {
         return ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new IllegalArgumentException("Ticket Not Found"));
+    }
+
+    public void updateTicketStatusUsed(LocalDate targetDate, LocalTime targetTime) {
+        ticketRepository.updateExpiredTickets(targetDate, targetTime);
     }
 }

--- a/src/test/java/com/noljo/nolzo/domain/ticket/service/TicketServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/ticket/service/TicketServiceTest.java
@@ -18,12 +18,18 @@ import com.noljo.nolzo.support.fixture.ScheduleFixture;
 import com.noljo.nolzo.support.fixture.SeatFixture;
 import com.noljo.nolzo.support.fixture.TicketFixture;
 import com.noljo.nolzo.ticket.entity.Ticket;
+import com.noljo.nolzo.ticket.entity.TicketStatus;
 import com.noljo.nolzo.ticket.repository.TicketRepository;
 import com.noljo.nolzo.ticket.service.TicketService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ServiceTest
 class TicketServiceTest {
@@ -63,5 +69,30 @@ class TicketServiceTest {
         ticketRepository.save(ticket);
 
         assertThat(ticketRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    void 공연시간_30분이_지나면_티켓상태_관람완료_변경() {
+        // given
+        Event event = eventRepository.save(EventFixture.햄릿());
+        Schedule schedule = scheduleRepository.save(ScheduleFixture.공연_스케쥴(event));
+        Seat seat = seatRepository.save(SeatFixture.일반좌석(schedule));
+
+        Member member = memberRepository.save(MemberFixture.회원());
+        Reservation reservation = reservationRepository.save(ReservationFixture.예약(member));
+
+        Ticket ticket = TicketFixture.미사용티켓(reservation, seat);
+        ticketRepository.save(ticket);
+
+        // 공연 시작 시간 + 31분을 기준 시간으로 설정
+        LocalDate baseDate = schedule.getShowDate();
+        LocalTime baseTime = schedule.getShowTime().plusMinutes(31);
+
+        // when
+        ticketService.updateTicketStatusUsed(baseDate,baseTime);
+
+        // then
+        Ticket updated = ticketRepository.findById(ticket.getId()).orElseThrow();
+        assertEquals(TicketStatus.USED, updated.getStatus());
     }
 }


### PR DESCRIPTION
## 📌 개요
- '@Scheduled` 어노테이션을 이용해 관람 시작 지나면 30분 마다 USED로 변경된  티켓 상태값이 `USED`로 변경되게 했습니다 

## 🛠️ 작업 내용
- 티켓완료 상태벼경 서비스로직(`updateTicketStatusUsed`) 작성
- 사용자 정의 쿼리문(`updateExpiredTickets`) 작성
- 스케쥴링 전용 설정 클래스 생성(`SchdeulerConfig`)
- 티켓 스케쥴러 클래스(`TickerScheduler`) 생성 및 `changeUsed` 메서드 작성
- 테스트 코드 작성

### `TicketScheduler`  클래스 설명

- `@Scheduled(fixedRate = 1800)` 설정을 통해 **30분 간격으로 티켓 상태를 점검**합니다.
- 내부적으로 `ticketService.updateTicketStatusUsed()` 메서드를 호출하여, 
  **관람 시작 시간 30분이 지난 티켓의 상태를 `USED`로 변경**합니다.
- 주기적 상태 업데이트를 통해 **관리자 개입 없이 자동 상태 전환**이 이루어지도록 합니다.


### `updateExpiredTickets` 메서드 설명
- `TicketScheduler`의 클래스에 `changeUsed`로 일정 간격(현재는 30분)에 한번 실행됨 
- "지금 시간이 공연 시작 + 30분 이상"인 티켓을 찾아 상태를 USED로 변경

## 📌 차후 계획 (Optional)
- 선택된 좌석에 대해서 lock 거는 방식을 redis 활용해 성능 비교 예정

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

close #112 