### PR TITLE
[Fix] ReservationDetail 응답 필드 변경

### DIFF
--- a/src/main/java/com/noljo/nolzo/reservation/dto/ReservationDetail.java
+++ b/src/main/java/com/noljo/nolzo/reservation/dto/ReservationDetail.java
@@ -3,24 +3,18 @@ package com.noljo.nolzo.reservation.dto;
 import com.noljo.nolzo.payment.entity.Payment;
 import com.noljo.nolzo.payment.entity.PaymentMethod;
 import com.noljo.nolzo.reservation.entity.Reservation;
-import com.noljo.nolzo.seat.dto.SeatResponse;
-import com.noljo.nolzo.seat.entity.Seat;
-import com.noljo.nolzo.ticket.entity.Ticket;
+import com.noljo.nolzo.ticket.dto.TicketResponse;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
-
-import java.util.List;
-
-import static java.util.stream.Collectors.toList;
 
 @Getter
 @Builder
 public class ReservationDetail {
 
     private Long id;
-    private List<SeatResponse> seats;
+    private List<TicketResponse> tickets;
     private String status;
     private int totalPrice;
     private String reservationNumber;
@@ -29,14 +23,9 @@ public class ReservationDetail {
 
 
     public static ReservationDetail from(Reservation reservation) {
-        List<SeatResponse> reservedSeats = reservation.getTickets().stream()
-                .map(Ticket::getSeat)
-                .map(SeatResponse::from)
-                .collect(toList());
-
         return ReservationDetail.builder()
                 .id(reservation.getId())
-                .seats(reservedSeats)
+                .tickets(mapTickets(reservation))
                 .status(reservation.getStatus().name())
                 .totalPrice(reservation.getTotalPrice())
                 .reservationNumber(reservation.getReservationNumber())
@@ -45,14 +34,9 @@ public class ReservationDetail {
     }
 
     public static ReservationDetail fromDetails(Reservation reservation, Payment payment) {
-        List<SeatResponse> reservedSeats = reservation.getTickets().stream()
-                .map(Ticket::getSeat)
-                .map(SeatResponse::from)
-                .collect(toList());
-
         return ReservationDetail.builder()
                 .id(reservation.getId())
-                .seats(reservedSeats)
+                .tickets(mapTickets(reservation))
                 .status(reservation.getStatus().name())
                 .totalPrice(reservation.getTotalPrice())
                 .reservationNumber(reservation.getReservationNumber())
@@ -60,5 +44,10 @@ public class ReservationDetail {
                 .paymentMethod(payment.getPaymentMethod())
                 .build();
     }
-}
 
+    private static List<TicketResponse> mapTickets(Reservation reservation) {
+        return reservation.getTickets().stream()
+                .map(TicketResponse::from)
+                .toList();
+    }
+}


### PR DESCRIPTION
## 📌 개요
내 예약 페이지에서 ReservationDetail 응답의 필드가 List seats로 구성되어 있어, 좌석 정보만 내려오고 예매 티켓에 대한 정보를 얻을 수 없는 문제가 발생해 seats를 ticket으로 변경

## 🛠️ 작업 내용
- [x] 변경 사항 요약
- [x] 주요 변경 사항 설명
- [x] 관련 이슈 번호 (`#121`)

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

### 📌 기타 참고 사항
mapTickets 메서드명을 일단 사용했는데, 혹시 더 나은 네이밍 제안이 있으시면 의견 부탁드립니다!

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.
close #121 