### PR TITLE
[Feature] 리뷰 조회 기능 구현

### DIFF
--- a/src/main/java/com/noljo/nolzo/auth/config/SecurityConfig.java
+++ b/src/main/java/com/noljo/nolzo/auth/config/SecurityConfig.java
@@ -56,8 +56,9 @@ public class SecurityConfig {
                         .requestMatchers("/auth/**", "/event/**").permitAll()
                         .requestMatchers(GET, "/reservations/reservation/**").permitAll()
                         .requestMatchers(POST, "/reservations/*").permitAll()
-                        .requestMatchers("/member/**", "/payments/**", "/reservations/**", "/tickets/**")
-                        .hasRole("USER")
+                        .requestMatchers(GET, "/reviews/*/").permitAll()
+                        .requestMatchers(GET, "/reviews/events/*").permitAll()
+                        .requestMatchers("/member/**", "/payments/**", "/reservations/**", "/reviews/**", "/tickets/**").hasRole("USER")
                         .anyRequest().authenticated())
 
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/noljo/nolzo/review/controller/ReviewController.java
+++ b/src/main/java/com/noljo/nolzo/review/controller/ReviewController.java
@@ -7,6 +7,7 @@ import com.noljo.nolzo.review.dto.request.ReviewCreateRequest;
 import com.noljo.nolzo.review.dto.response.ReviewResponse;
 import com.noljo.nolzo.review.service.ReviewService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,6 +30,13 @@ public class ReviewController {
     @GetMapping("/{reviewId}")
     public ResponseEntity<ReviewResponse> getReview(@PathVariable Long reviewId) {
         ReviewResponse response = reviewService.getReview(reviewId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Transactional(readOnly = true)
+    @GetMapping("/my")
+    public ResponseEntity<List<ReviewResponse>> getMemberReview(@AuthenticationPrincipal(expression = "memberId") Long memberId) {
+        List<ReviewResponse> response = reviewService.getReviewsByMemberId(memberId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/noljo/nolzo/review/controller/ReviewController.java
+++ b/src/main/java/com/noljo/nolzo/review/controller/ReviewController.java
@@ -2,6 +2,7 @@ package com.noljo.nolzo.review.controller;
 
 import com.noljo.nolzo.auth.security.CustomUserDetails;
 import com.noljo.nolzo.review.dto.request.ReviewUpdateRequest;
+import com.noljo.nolzo.review.dto.response.EventReviewDetailsResponse;
 import com.noljo.nolzo.review.dto.response.ReviewUpdateResponse;
 import com.noljo.nolzo.review.dto.request.ReviewCreateRequest;
 import com.noljo.nolzo.review.dto.response.ReviewResponse;
@@ -11,7 +12,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,8 +19,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/reviews")
 public class ReviewController {
@@ -45,6 +46,13 @@ public class ReviewController {
     public ResponseEntity<ReviewResponse> getMyReviewByEvent(
             @AuthenticationPrincipal(expression = "memberId") Long memberId, @PathVariable Long eventId) {
         ReviewResponse response = reviewService.getReviewByMemberIdAndEventId(memberId, eventId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Transactional(readOnly = true)
+    @GetMapping("/events/{eventId}")
+    public ResponseEntity<EventReviewDetailsResponse> getReviewsByEvent(@PathVariable Long eventId) {
+        EventReviewDetailsResponse response = reviewService.getReviewsByEventId(eventId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/noljo/nolzo/review/controller/ReviewController.java
+++ b/src/main/java/com/noljo/nolzo/review/controller/ReviewController.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +24,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/reviews")
 public class ReviewController {
     private final ReviewService reviewService;
+
+    @Transactional(readOnly = true)
+    @GetMapping("/{reviewId}")
+    public ResponseEntity<ReviewResponse> getReview(@PathVariable Long reviewId) {
+        ReviewResponse response = reviewService.getReview(reviewId);
+        return ResponseEntity.ok(response);
+    }
 
     @PostMapping
     public ResponseEntity<ReviewResponse> createReview(@AuthenticationPrincipal CustomUserDetails user, @Valid @RequestBody ReviewCreateRequest request) {

--- a/src/main/java/com/noljo/nolzo/review/controller/ReviewController.java
+++ b/src/main/java/com/noljo/nolzo/review/controller/ReviewController.java
@@ -40,6 +40,14 @@ public class ReviewController {
         return ResponseEntity.ok(response);
     }
 
+    @Transactional(readOnly = true)
+    @GetMapping("/events/{eventId}/my")
+    public ResponseEntity<ReviewResponse> getMyReviewByEvent(
+            @AuthenticationPrincipal(expression = "memberId") Long memberId, @PathVariable Long eventId) {
+        ReviewResponse response = reviewService.getReviewByMemberIdAndEventId(memberId, eventId);
+        return ResponseEntity.ok(response);
+    }
+
     @PostMapping
     public ResponseEntity<ReviewResponse> createReview(@AuthenticationPrincipal CustomUserDetails user, @Valid @RequestBody ReviewCreateRequest request) {
         ReviewResponse response = reviewService.create(user.getMemberId(), request);

--- a/src/main/java/com/noljo/nolzo/review/controller/ReviewController.java
+++ b/src/main/java/com/noljo/nolzo/review/controller/ReviewController.java
@@ -12,7 +12,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/src/main/java/com/noljo/nolzo/review/dto/response/EventReviewDetailsResponse.java
+++ b/src/main/java/com/noljo/nolzo/review/dto/response/EventReviewDetailsResponse.java
@@ -1,0 +1,10 @@
+package com.noljo.nolzo.review.dto.response;
+
+import java.util.List;
+
+public record EventReviewDetailsResponse(
+        double averageRating,
+        int reviewCount,
+        List<ReviewDetailResponse> reviews
+) {
+}

--- a/src/main/java/com/noljo/nolzo/review/dto/response/ReviewDetailResponse.java
+++ b/src/main/java/com/noljo/nolzo/review/dto/response/ReviewDetailResponse.java
@@ -1,0 +1,22 @@
+package com.noljo.nolzo.review.dto.response;
+
+import com.noljo.nolzo.review.entity.Review;
+import java.time.LocalDateTime;
+
+public record ReviewDetailResponse(
+        Long id,
+        String content,
+        int rating,
+        String author,
+        LocalDateTime createdAt
+) {
+    public static ReviewDetailResponse from(Review review) {
+        return new ReviewDetailResponse(
+                review.getId(),
+                review.getContent(),
+                review.getRating(),
+                review.getMember().getName(),
+                review.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/noljo/nolzo/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/noljo/nolzo/review/dto/response/ReviewResponse.java
@@ -7,6 +7,7 @@ public record ReviewResponse(
         Long id,
         String content,
         int rating,
+        Long eventId,
         LocalDateTime createdAt
 ) {
     public static ReviewResponse from(Review review) {
@@ -14,6 +15,7 @@ public record ReviewResponse(
                 review.getId(),
                 review.getContent(),
                 review.getRating(),
+                review.getEvent().getId(),
                 review.getCreatedAt()
         );
     }

--- a/src/main/java/com/noljo/nolzo/review/repository/ReviewRepository.java
+++ b/src/main/java/com/noljo/nolzo/review/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.noljo.nolzo.review.repository;
 
 import com.noljo.nolzo.review.entity.Review;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
@@ -9,5 +10,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         return findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("리뷰가 존재하지 않습니다."));
     }
+
+    List<Review> findByMemberId(Long memberId);
+
     Optional<Object> findByMemberIdAndEventId(Long memberId, Long eventId);
 }

--- a/src/main/java/com/noljo/nolzo/review/repository/ReviewRepository.java
+++ b/src/main/java/com/noljo/nolzo/review/repository/ReviewRepository.java
@@ -13,5 +13,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findByMemberId(Long memberId);
 
-    Optional<Object> findByMemberIdAndEventId(Long memberId, Long eventId);
+    Optional<Review> findByMemberIdAndEventId(Long memberId, Long eventId);
 }

--- a/src/main/java/com/noljo/nolzo/review/repository/ReviewRepository.java
+++ b/src/main/java/com/noljo/nolzo/review/repository/ReviewRepository.java
@@ -14,4 +14,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findByMemberId(Long memberId);
 
     Optional<Review> findByMemberIdAndEventId(Long memberId, Long eventId);
+
+    List<Review> findByEventId(Long eventId);
 }

--- a/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
+++ b/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
@@ -12,6 +12,7 @@ import com.noljo.nolzo.review.dto.response.ReviewResponse;
 import com.noljo.nolzo.review.entity.Review;
 import com.noljo.nolzo.review.repository.ReviewRepository;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,6 +54,12 @@ public class ReviewService {
         return reviews.stream()
                 .map(ReviewResponse::from)
                 .toList();
+    }
+
+    public ReviewResponse getReviewByMemberIdAndEventId(Long memberId, Long eventId) {
+        Review review = reviewRepository.findByMemberIdAndEventId(memberId, eventId)
+                .orElseThrow(() -> new IllegalArgumentException("리뷰를 조회할 수 없습니다"));
+        return ReviewResponse.from(review);
     }
 
     private void validateReviewOwner(Review review, Long memberId) {

--- a/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
+++ b/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
@@ -1,6 +1,8 @@
 package com.noljo.nolzo.review.service;
 
 import com.noljo.nolzo.review.dto.request.ReviewUpdateRequest;
+import com.noljo.nolzo.review.dto.response.EventReviewDetailsResponse;
+import com.noljo.nolzo.review.dto.response.ReviewDetailResponse;
 import com.noljo.nolzo.review.dto.response.ReviewUpdateResponse;
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.repository.EventRepository;
@@ -12,7 +14,6 @@ import com.noljo.nolzo.review.dto.response.ReviewResponse;
 import com.noljo.nolzo.review.entity.Review;
 import com.noljo.nolzo.review.repository.ReviewRepository;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,6 +63,12 @@ public class ReviewService {
         return ReviewResponse.from(review);
     }
 
+    public EventReviewDetailsResponse getReviewsByEventId(Long eventId) {
+        List<ReviewDetailResponse> reviews  = findDetailReviewsByEvent(eventId);
+        double averageRating = getAverageRating(reviews);
+        return new EventReviewDetailsResponse(averageRating, reviews.size(), reviews);
+    }
+
     private void validateReviewOwner(Review review, Long memberId) {
         if (!review.getMember().getId().equals(memberId)) {
             throw new IllegalStateException("해당 리뷰를 수정할 권한이 없습니다.");
@@ -82,5 +89,19 @@ public class ReviewService {
         if (isAlreadyReviewed) {
             throw new IllegalStateException("이미 해당 이벤트에 대한 리뷰를 작성하였습니다.");
         }
+    }
+
+    private List<ReviewDetailResponse> findDetailReviewsByEvent(Long eventId) {
+        return reviewRepository.findByEventId(eventId)
+                .stream()
+                .map(ReviewDetailResponse::from)
+                .toList();
+    }
+
+    private static double getAverageRating(List<ReviewDetailResponse> reviews) {
+        return reviews.stream()
+                .mapToInt(ReviewDetailResponse::rating)
+                .average()
+                .orElse(0.0);
     }
 }

--- a/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
+++ b/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
@@ -11,6 +11,7 @@ import com.noljo.nolzo.review.dto.request.ReviewCreateRequest;
 import com.noljo.nolzo.review.dto.response.ReviewResponse;
 import com.noljo.nolzo.review.entity.Review;
 import com.noljo.nolzo.review.repository.ReviewRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,6 +46,13 @@ public class ReviewService {
     public ReviewResponse getReview(Long reviewId) {
         Review review = reviewRepository.getOrThrow(reviewId);
         return ReviewResponse.from(review);
+    }
+
+    public List<ReviewResponse> getReviewsByMemberId(Long memberId) {
+        List<Review> reviews = reviewRepository.findByMemberId(memberId);
+        return reviews.stream()
+                .map(ReviewResponse::from)
+                .toList();
     }
 
     private void validateReviewOwner(Review review, Long memberId) {

--- a/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
+++ b/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
@@ -42,6 +42,11 @@ public class ReviewService {
         return ReviewUpdateResponse.from(review);
     }
 
+    public ReviewResponse getReview(Long reviewId) {
+        Review review = reviewRepository.getOrThrow(reviewId);
+        return ReviewResponse.from(review);
+    }
+
     private void validateReviewOwner(Review review, Long memberId) {
         if (!review.getMember().getId().equals(memberId)) {
             throw new IllegalStateException("해당 리뷰를 수정할 권한이 없습니다.");

--- a/src/test/java/com/noljo/nolzo/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/review/service/ReviewServiceTest.java
@@ -5,7 +5,6 @@ import com.noljo.nolzo.event.repository.EventRepository;
 import com.noljo.nolzo.member.entity.Member;
 import com.noljo.nolzo.member.repository.MemberRepository;
 import com.noljo.nolzo.review.dto.request.ReviewUpdateRequest;
-import com.noljo.nolzo.review.dto.response.EventReviewDetailsResponse;
 import com.noljo.nolzo.review.dto.response.ReviewResponse;
 import com.noljo.nolzo.review.dto.response.ReviewUpdateResponse;
 import com.noljo.nolzo.review.dto.request.ReviewCreateRequest;
@@ -130,5 +129,5 @@ public class ReviewServiceTest {
 
         reviewService.delete(member.getId(), review.getId());
         assertThat(reviewRepository.findById(review.getId())).isEmpty();
-    } 
+    }
 }

--- a/src/test/java/com/noljo/nolzo/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/review/service/ReviewServiceTest.java
@@ -5,6 +5,7 @@ import com.noljo.nolzo.event.repository.EventRepository;
 import com.noljo.nolzo.member.entity.Member;
 import com.noljo.nolzo.member.repository.MemberRepository;
 import com.noljo.nolzo.review.dto.request.ReviewUpdateRequest;
+import com.noljo.nolzo.review.dto.response.ReviewResponse;
 import com.noljo.nolzo.review.dto.response.ReviewUpdateResponse;
 import com.noljo.nolzo.review.dto.request.ReviewCreateRequest;
 import com.noljo.nolzo.review.entity.Review;
@@ -76,5 +77,21 @@ public class ReviewServiceTest {
 
         assertThat(response.content()).isEqualTo("수정된 리뷰");
         assertThat(response.rating()).isEqualTo(5);
+    }
+
+    @Test
+    void 이벤트_ID와_회원_ID로_관련_리뷰를_조회할_수_있다() {
+        Member member = MemberFixture.회원();
+        memberRepository.save(member);
+
+        Event event = EventFixture.캣츠();
+        eventRepository.save(event);
+
+        Review review = ReviewFixture.연극리뷰(event, member);
+        reviewRepository.save(review);
+
+        ReviewResponse result = reviewService.getReviewByMemberIdAndEventId(member.getId(), event.getId());
+        assertThat(result.content()).isEqualTo(review.getContent());
+        assertThat(result.rating()).isEqualTo(review.getRating());
     }
 }

--- a/src/test/java/com/noljo/nolzo/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/review/service/ReviewServiceTest.java
@@ -5,6 +5,7 @@ import com.noljo.nolzo.event.repository.EventRepository;
 import com.noljo.nolzo.member.entity.Member;
 import com.noljo.nolzo.member.repository.MemberRepository;
 import com.noljo.nolzo.review.dto.request.ReviewUpdateRequest;
+import com.noljo.nolzo.review.dto.response.EventReviewDetailsResponse;
 import com.noljo.nolzo.review.dto.response.ReviewResponse;
 import com.noljo.nolzo.review.dto.response.ReviewUpdateResponse;
 import com.noljo.nolzo.review.dto.request.ReviewCreateRequest;
@@ -93,5 +94,26 @@ public class ReviewServiceTest {
         ReviewResponse result = reviewService.getReviewByMemberIdAndEventId(member.getId(), event.getId());
         assertThat(result.content()).isEqualTo(review.getContent());
         assertThat(result.rating()).isEqualTo(review.getRating());
+    }
+
+    @Test
+    void 이벤트_ID로_리뷰_상세_정보를_조회할_수_있다() {
+        Member member1 = MemberFixture.회원();
+        Member member2 = MemberFixture.회투();
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+
+        Event event = EventFixture.캣츠();
+        eventRepository.save(event);
+
+        Review review1 = ReviewFixture.연극리뷰(event, member1);
+        Review review2 = ReviewFixture.연극리뷰(event, member2);
+        reviewRepository.save(review1);
+        reviewRepository.save(review2);
+
+        var result = reviewService.getReviewsByEventId(event.getId());
+
+        assertThat(result.reviewCount()).isEqualTo(2);
+        assertThat(result.averageRating()).isEqualTo((review1.getRating() + review2.getRating()) / 2.0);
     }
 }


### PR DESCRIPTION
## 📌 개요
- 리뷰 조회 관련 API를 구현
  - review 단건 조회
  - 회원이 작성한 리뷰들 조회
  - 이벤트와 관련된 리뷰들 조회
  - 이벤트 ID와 회원정보로 이 이벤트에 회원이 작성한 리뷰 단건 조회
   (프론트 흐름상 관람이 완료된 이벤트의 리뷰를 작성할 때 필요한 API)
- 리뷰 페이징 처리 및 평균 평점 계산 로직의 성능 개선 작업 진행 예정
## 🛠️ 작업 내용
- [x] 변경 사항 요약
- [x] 주요 변경 사항 설명
- [x] 관련 이슈 번호 (`#107`)

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인
<img width="746" alt="image" src="https://github.com/user-attachments/assets/27b21d9b-17ae-4315-8b90-6bb7317ade65" />

### 📌 기타 참고 사항
일단은 이벤트와 관련된 전체 리뷰들을 가져오도록 구현하였습니다.
이벤트에 대한 리뷰 수가 많아질 경우, 이벤트 조회 시 성능 저하가 발생할 수 있습니다.
이에 따라, 추후 리뷰 페이징 처리 및 평균 평점 계산 로직의 성능 개선 작업을 진행할 예정입니다.

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.
close #107 