### PR TITLE
[Feature] 예약 취소 기능 구현

### DIFF
--- a/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
+++ b/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
@@ -2,10 +2,7 @@ package com.noljo.nolzo.reservation.controller;
 
 
 import com.noljo.nolzo.auth.security.CustomUserDetails;
-import com.noljo.nolzo.reservation.dto.ReservationEventInfo;
-import com.noljo.nolzo.reservation.dto.EventDateTimeResponse;
-import com.noljo.nolzo.reservation.dto.ReservationRequest;
-import com.noljo.nolzo.reservation.dto.ReservationResponse;
+import com.noljo.nolzo.reservation.dto.*;
 import com.noljo.nolzo.reservation.service.ReservationService;
 import com.noljo.nolzo.seat.dto.SeatResponse;
 import com.noljo.nolzo.seat.service.SeatService;
@@ -89,5 +86,12 @@ public class ReservationController {
             @RequestParam String date,
             @RequestParam String time) {
         return ResponseEntity.ok(seatService.findSeats(eventId, date, time));
+    }
+
+    @DeleteMapping("/reservation/{reservationId}")
+    public ResponseEntity<ReservationCancelResponse> cancelReservation(
+            @AuthenticationPrincipal(expression = "memberId") Long memberId,
+            @PathVariable Long reservationId){
+        return ResponseEntity.ok(reservationService.cancelReservationById(memberId,reservationId));
     }
 }

--- a/src/main/java/com/noljo/nolzo/reservation/dto/ReservationCancelResponse.java
+++ b/src/main/java/com/noljo/nolzo/reservation/dto/ReservationCancelResponse.java
@@ -1,0 +1,20 @@
+package com.noljo.nolzo.reservation.dto;
+
+import com.noljo.nolzo.reservation.entity.Reservation;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReservationCancelResponse {
+
+    private Long id;
+    private String status;
+
+    public static ReservationCancelResponse from(Reservation reservation) {
+        return ReservationCancelResponse.builder()
+                .id(reservation.getId())
+                .status(reservation.getStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/com/noljo/nolzo/reservation/entity/Reservation.java
+++ b/src/main/java/com/noljo/nolzo/reservation/entity/Reservation.java
@@ -53,4 +53,8 @@ public class Reservation extends BaseEntity {
     public void updateStatus(ReservationStatus reservationStatus) {
         this.status = reservationStatus;
     }
+
+    public void cancelAllTickets() {
+        this.tickets.forEach(Ticket::cancel);
+    }
 }

--- a/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
+++ b/src/main/java/com/noljo/nolzo/reservation/service/ReservationService.java
@@ -134,5 +134,20 @@ public class ReservationService {
             ticketService.create(reservation, seat);
         }
     }
+
+    public ReservationCancelResponse cancelReservationById(Long memberId, Long reservationId) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 예약 정보가 없습니다"));
+
+        if(!reservation.getMember().getId().equals(memberId)){
+            throw new IllegalArgumentException("해당 예약자만 예약을 취소할 수 있습니다");
+        }
+
+        reservation.softDelete();
+        reservation.updateStatus(ReservationStatus.CANCELLED);
+        reservation.cancelAllTickets();
+
+        return ReservationCancelResponse.from(reservation);
+    }
 }
 

--- a/src/main/java/com/noljo/nolzo/ticket/entity/Ticket.java
+++ b/src/main/java/com/noljo/nolzo/ticket/entity/Ticket.java
@@ -43,4 +43,8 @@ public class Ticket extends BaseEntity {
         this.reservation = reservation;
         this.seat = seat;
     }
+
+    public void cancel() {
+        this.status = TicketStatus.CANCELLED;
+    }
 }

--- a/src/main/java/com/noljo/nolzo/ticket/entity/Ticket.java
+++ b/src/main/java/com/noljo/nolzo/ticket/entity/Ticket.java
@@ -3,6 +3,7 @@ package com.noljo.nolzo.ticket.entity;
 import com.noljo.nolzo.global.BaseEntity;
 import com.noljo.nolzo.reservation.entity.Reservation;
 import com.noljo.nolzo.seat.entity.Seat;
+import com.noljo.nolzo.seat.entity.SeatStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -46,5 +47,6 @@ public class Ticket extends BaseEntity {
 
     public void cancel() {
         this.status = TicketStatus.CANCELLED;
+        seat.updateStatus(SeatStatus.AVAILABLE);
     }
 }

--- a/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/reservation/service/ReservationServiceTest.java
@@ -12,6 +12,7 @@ import com.noljo.nolzo.reservation.dto.EventDateTimeResponse;
 import com.noljo.nolzo.reservation.dto.ReservationEventInfo;
 import com.noljo.nolzo.reservation.dto.ReservationRequest;
 import com.noljo.nolzo.reservation.entity.Reservation;
+import com.noljo.nolzo.reservation.entity.ReservationStatus;
 import com.noljo.nolzo.reservation.repository.ReservationRepository;
 import com.noljo.nolzo.reservation.service.ReservationService;
 import com.noljo.nolzo.schedule.entity.Schedule;
@@ -20,6 +21,7 @@ import com.noljo.nolzo.seat.entity.Seat;
 import com.noljo.nolzo.seat.repository.SeatRepository;
 import com.noljo.nolzo.support.annotation.ServiceTest;
 import com.noljo.nolzo.support.fixture.*;
+import com.noljo.nolzo.ticket.entity.TicketStatus;
 import com.noljo.nolzo.ticket.repository.TicketRepository;
 
 import org.junit.jupiter.api.Test;
@@ -115,4 +117,24 @@ public class ReservationServiceTest {
         assertThatThrownBy(() -> reservationService.readSelectedEventDateTime(event.getId(), correctDate, wrongTime))
                 .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void 예매한_공연에_대해서_취소() {
+        //given
+        Member member = memberRepository.save(MemberFixture.회원());
+        Reservation reservation = reservationRepository.save(ReservationFixture.예약(member));
+        Reservation reservation2 = reservationRepository.save(ReservationFixture.예약2(member));
+
+        //when
+        reservationService.cancelReservationById(member.getId(), reservation.getId());
+        //then
+        Reservation cancelledReservation = reservationRepository.findById(reservation.getId())
+                .orElseThrow(() -> new AssertionError("취소된 예약을 찾을 수 없습니다."));
+
+        assertEquals(ReservationStatus.CANCELLED,cancelledReservation.getStatus());
+        reservation.getTickets().forEach(ticket ->
+                assertEquals(TicketStatus.CANCELLED, ticket.getStatus()));
+        reservation2.getTickets().forEach(ticket ->
+                assertEquals(TicketStatus.NOT_USED, ticket.getStatus()));
+        }
 }


### PR DESCRIPTION
## 📌 개요
- 예매한 공연에 대해 취소할 수 있으며, 예매 취소 시 관련 티켓도 함께 취소됩니다.

## 🛠️ 작업 내용
- [x] 예약 취소 API 구현 (`cancelReservation`)
- [x] 예약 취소 서비스 로직 작성(`cancelReservationById`)
- [x] 예약 취소 응답 dto 작성(`ReservationCancelResponse`)
- [x] `Reservaion` 및 `Ticket` 에 비즈니스 로직 추가(`cancelAllTickets`,`cancel`)
- [x] 테스트 로직 작성


## 📌 차후 계획 (Optional)
- 좌석 선택 기능에 대해 부하 테스트 후 리팩토링 예정

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---
close #137 