### PR TITLE
[Feature] embeddedRedis로 테스트 환경 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testRuntimeOnly 'com.h2database:h2'
+	testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
 
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/test/java/com/noljo/nolzo/support/RedisServerExtension.java
+++ b/src/test/java/com/noljo/nolzo/support/RedisServerExtension.java
@@ -1,0 +1,27 @@
+package com.noljo.nolzo.support;
+
+import java.io.IOException;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import redis.embedded.RedisServer;
+
+public class RedisServerExtension implements BeforeAllCallback, AfterAllCallback {
+    private static RedisServer redisServer;
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws IOException {
+        if (redisServer == null) {
+            redisServer = new RedisServer(63790);
+            redisServer.start();
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws IOException {
+        if (redisServer != null) {
+            redisServer.stop();
+            redisServer = null;
+        }
+    }
+}

--- a/src/test/java/com/noljo/nolzo/support/RedisTemplateTests.java
+++ b/src/test/java/com/noljo/nolzo/support/RedisTemplateTests.java
@@ -7,20 +7,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class RedisTemplateTests {
-//    @Autowired
-//    private RedisTemplate<String, String> redisTemplate;
-//
-//    @Test
-//    @DisplayName("Redis 동작 테스트")
-//    void redisTemplateString() {
-//        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-//
-//        String key = "name";
-//        valueOperations.set(key, "NOLZO");
-//        String value = valueOperations.get(key);
-//        Assertions.assertEquals(value, "NOLZO");
-//    }
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Test
+    @DisplayName("Redis 동작 테스트")
+    void redisTemplateString() {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+        String key = "name";
+        valueOperations.set(key, "NOLZO");
+        String value = valueOperations.get(key);
+        Assertions.assertEquals(value, "NOLZO");
+    }
 }

--- a/src/test/java/com/noljo/nolzo/support/RedisTemplateTests.java
+++ b/src/test/java/com/noljo/nolzo/support/RedisTemplateTests.java
@@ -1,15 +1,15 @@
 package com.noljo.nolzo.support;
 
+import com.noljo.nolzo.support.annotation.ServiceTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@ServiceTest
 @ActiveProfiles("test")
 class RedisTemplateTests {
 

--- a/src/test/java/com/noljo/nolzo/support/annotation/ServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/support/annotation/ServiceTest.java
@@ -1,6 +1,7 @@
 package com.noljo.nolzo.support.annotation;
 
 import com.noljo.nolzo.support.DatabaseCleanerExtension;
+import com.noljo.nolzo.support.RedisServerExtension;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -14,6 +15,6 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @Retention(RetentionPolicy.RUNTIME)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@ExtendWith(DatabaseCleanerExtension.class)
+@ExtendWith({DatabaseCleanerExtension.class, RedisServerExtension.class})
 public @interface ServiceTest {
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,5 +1,9 @@
 spring:
   config.activate.on-profile: "test"
+  data:
+    redis:
+      host: localhost
+      port: 63790
   datasource:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:nolzo;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE


### PR DESCRIPTION
## 📌 개요
Redis의 로컬과 테스트 환경 분리를 위해 EmbeddedRedis 도입

## 🛠️ 작업 내용
- [x] 변경 사항 요약
- [x] 주요 변경 사항 설명
- [x] 관련 이슈 번호 (`#140`)

### RedisServerExtension
- BeforeAllCallback을 구현하여 테스트 클래스의 모든 테스트 메서드가 실행되기 전에 Embedded Redis 서버(포트 63790)를 시작합니다.
- AfterAllCallback을 구현하여 모든 테스트 메서드가 실행된 후에 Redis 서버를 안전하게 중지합니다.
- static 필드를 사용하여 Redis 서버 인스턴스를 관리하므로, 동일한 테스트 클래스 내의 여러 테스트 메서드가 동일한 Redis 인스턴스를 공유합니다.
- 기존 `@ServiceTest`에 `RedisServerExtension`추가하여 기존 테스트와 충돌이 없도록 구성했습니다.

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인
<img width="659" alt="image" src="https://github.com/user-attachments/assets/ee7180cf-899c-4f5a-ab1b-4e3481d96dba" />

### 📌 기타 참고 사항
- 윈도우 환경에서 테스트 실행을 하지 못했습니다. 혹시 테스트가 정상적으로 안되면 공유 부탁드립니다.
---
#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.
close #140