### PR TITLE
[Feature] 이벤트 업데이트 스케줄 반영 #142

### DIFF
--- a/src/main/java/com/noljo/nolzo/event/controller/EventController.java
+++ b/src/main/java/com/noljo/nolzo/event/controller/EventController.java
@@ -55,7 +55,7 @@ public class EventController {
         return ResponseEntity.ok(eventService.getTop6PopularEvents());
     }
 
-    @PutMapping("/{id}")
+    @PatchMapping("/{id}")
     public ResponseEntity<EventResponse> updateEvent(@PathVariable Long id, @RequestBody @Valid EventUpdateRequest dto) {
         return ResponseEntity.ok(eventService.update(id, dto));
     }

--- a/src/main/java/com/noljo/nolzo/event/controller/EventController.java
+++ b/src/main/java/com/noljo/nolzo/event/controller/EventController.java
@@ -55,8 +55,21 @@ public class EventController {
         return ResponseEntity.ok(eventService.getTop6PopularEvents());
     }
 
+    @PatchMapping(value = "/{id}",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<EventResponse> updateEvent(
+            @PathVariable Long id,
+            @RequestPart("dto") @Valid EventUpdateRequest dto,
+            @RequestPart(value = "eventImage", required = false) MultipartFile image
+    ) {
+        return ResponseEntity.ok(eventService.update(id, dto));
+    }
+
     @PatchMapping("/{id}")
-    public ResponseEntity<EventResponse> updateEvent(@PathVariable Long id, @RequestBody @Valid EventUpdateRequest dto) {
+    public ResponseEntity<EventResponse> updateJson(
+            @PathVariable Long id,
+            @RequestBody @Valid EventUpdateRequest dto
+    ) {
         return ResponseEntity.ok(eventService.update(id, dto));
     }
 

--- a/src/main/java/com/noljo/nolzo/event/dto/EventResponse.java
+++ b/src/main/java/com/noljo/nolzo/event/dto/EventResponse.java
@@ -27,8 +27,6 @@ public class EventResponse {
     private int rating;
     private int reviewCount;
     private long viewCount;
-    private LocalDateTime reservationStart;
-    private LocalDateTime reservationEnd;
 
     public static EventResponse from(Event event) {
         List<ScheduleResponse> schedules = event.getSchedules().stream()

--- a/src/main/java/com/noljo/nolzo/event/dto/EventUpdateRequest.java
+++ b/src/main/java/com/noljo/nolzo/event/dto/EventUpdateRequest.java
@@ -33,13 +33,8 @@ public class EventUpdateRequest {
     @NotNull(message = "종료 입력 필수")
     private LocalDate endDate;
 
-    @NotNull (message = "예약시작시점 지정 필수")
-    private LocalDateTime reservationStart;
-    @NotNull (message = "예약종료시점 지정 필수")
-    private LocalDateTime reservationEnd;
-
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
-    private List<ScheduleInfo> schedule;
+    private List<ScheduleInfo> schedules;
 
     public Event toEntity(Event original) {
         return Event.builder()

--- a/src/main/java/com/noljo/nolzo/event/entity/Event.java
+++ b/src/main/java/com/noljo/nolzo/event/entity/Event.java
@@ -5,9 +5,11 @@ import com.noljo.nolzo.schedule.dto.internal.ScheduleInfo;
 import com.noljo.nolzo.schedule.entity.Schedule;
 import com.noljo.nolzo.global.BaseEntity;
 import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -83,22 +85,22 @@ public class Event extends BaseEntity {
         this.viewCount++;
     }
 
-    public void validUpdateSchedule(Schedule dto){
-        if(dto.getReservationStart().isBefore(LocalDateTime.now())){
-                throw new IllegalStateException("예약시점 후에는 스케줄 변경 불가");
+    public void validUpdateSchedule(Schedule dto) {
+        if (dto.getReservationStart().isBefore(LocalDateTime.now())) {
+            throw new IllegalStateException("예약시점 후에는 스케줄 변경 불가");
         }
     }
-    public void validAddSchedule(Schedule dto){
-        LocalDateTime startEvent =LocalDateTime.of(this.startDate.minusDays(1),LocalTime.of(23,59));
-        LocalDateTime endEvent =LocalDateTime.of(this.endDate,LocalTime.of(23,59));
-            if(startEvent.isAfter(LocalDateTime.of(dto.getShowDate(),dto.getShowTime()))){
-                throw new IllegalStateException("시작시점 전에는 스케줄 추가 불가");
-            }
-            if(endEvent.isBefore(LocalDateTime.of(dto.getShowDate(),dto.getShowTime()))){
-                throw new IllegalStateException("종료시점 후에는 스케줄 추가 불가");
-            }
-        }
 
+    public void validAddSchedule(Schedule dto) {
+        LocalDateTime startEvent = LocalDateTime.of(this.startDate.minusDays(1), LocalTime.of(23, 59));
+        LocalDateTime endEvent = LocalDateTime.of(this.endDate, LocalTime.of(23, 59));
+        if (startEvent.isAfter(LocalDateTime.of(dto.getShowDate(), dto.getShowTime()))) {
+            throw new IllegalStateException("시작시점 전에는 스케줄 추가 불가");
+        }
+        if (endEvent.isBefore(LocalDateTime.of(dto.getShowDate(), dto.getShowTime()))) {
+            throw new IllegalStateException("종료시점 후에는 스케줄 추가 불가");
+        }
+    }
 
 
     public void updateFrom(EventUpdateRequest dto) {
@@ -108,28 +110,32 @@ public class Event extends BaseEntity {
         Optional.ofNullable(dto.getDescription()).ifPresent(d -> this.description = d);
         Optional.ofNullable(dto.getStartDate()).ifPresent(sd -> this.startDate = sd);
         Optional.ofNullable(dto.getEndDate()).ifPresent(ed -> this.endDate = ed);
-        if (dto.getSchedules()!=null) {
+        if (dto.getSchedules() != null) {
             Map<Long, Schedule> originalSchedule = schedules.stream()
                     .collect(Collectors.toMap(Schedule::getId, Function.identity()));
             for (ScheduleInfo schedule : dto.getSchedules()) {
-                if (schedule.getId() != null && originalSchedule.containsKey(schedule.getId())) {
-                    Schedule selectedSchedule = originalSchedule.remove(schedule.getId());
-                    validUpdateSchedule(selectedSchedule);
-                    selectedSchedule.updateFrom(schedule.getShowDate(), schedule.getShowTime(),schedule.getReservationStart(),schedule.getReservationEnd());
-                } else {
-                    Schedule newSchedule = Schedule.builder().showDate(schedule.getShowDate())
-                            .showTime(schedule.getShowTime())
-                            .reservationStart(schedule.getReservationStart())
-                            .reservationEnd(schedule.getReservationEnd())
-                            .build();
-                    newSchedule.setEvent(this);
-                    schedules.add(newSchedule);
-                }
+                manageSchedule(schedule,originalSchedule);
             }
             for (Schedule removeTarget : originalSchedule.values()) {
                 schedules.remove(removeTarget);
             }
         }
-
     }
+
+    public void manageSchedule(ScheduleInfo schedule, Map<Long, Schedule> originalSchedule) {
+        if (schedule.getId() != null && originalSchedule.containsKey(schedule.getId())) {
+            Schedule selectedSchedule = originalSchedule.remove(schedule.getId());
+            validUpdateSchedule(selectedSchedule);
+            selectedSchedule.updateFrom(schedule.getShowDate(), schedule.getShowTime(), schedule.getReservationStart(), schedule.getReservationEnd());
+        } else {
+            Schedule newSchedule = Schedule.builder().showDate(schedule.getShowDate())
+                    .showTime(schedule.getShowTime())
+                    .reservationStart(schedule.getReservationStart())
+                    .reservationEnd(schedule.getReservationEnd())
+                    .build();
+            newSchedule.setEvent(this);
+            schedules.add(newSchedule);
+        }
+    }
+
 }

--- a/src/main/java/com/noljo/nolzo/event/entity/Event.java
+++ b/src/main/java/com/noljo/nolzo/event/entity/Event.java
@@ -1,18 +1,25 @@
 package com.noljo.nolzo.event.entity;
 
 import com.noljo.nolzo.event.dto.EventUpdateRequest;
+import com.noljo.nolzo.schedule.dto.internal.ScheduleInfo;
 import com.noljo.nolzo.schedule.entity.Schedule;
 import com.noljo.nolzo.global.BaseEntity;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
+
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -47,7 +54,7 @@ public class Event extends BaseEntity {
     @Column(nullable = false)
     private long viewCount = 0;
 
-    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Schedule> schedules = new ArrayList<>();
 
     @Builder
@@ -66,20 +73,63 @@ public class Event extends BaseEntity {
     }
 
     public void addSchedule(Schedule schedule) {
+        validAddSchedule(schedule);
         schedules.add(schedule);
         schedule.setEvent(this);
     }
+
 
     public void addViewCount() {
         this.viewCount++;
     }
 
+    public void validUpdateSchedule(Schedule dto){
+        if(dto.getReservationStart().isBefore(LocalDateTime.now())){
+                throw new IllegalStateException("예약시점 후에는 스케줄 변경 불가");
+        }
+    }
+    public void validAddSchedule(Schedule dto){
+        LocalDateTime startEvent =LocalDateTime.of(this.startDate.minusDays(1),LocalTime.of(23,59));
+        LocalDateTime endEvent =LocalDateTime.of(this.endDate,LocalTime.of(23,59));
+            if(startEvent.isAfter(LocalDateTime.of(dto.getShowDate(),dto.getShowTime()))){
+                throw new IllegalStateException("시작시점 전에는 스케줄 추가 불가");
+            }
+            if(endEvent.isBefore(LocalDateTime.of(dto.getShowDate(),dto.getShowTime()))){
+                throw new IllegalStateException("종료시점 후에는 스케줄 추가 불가");
+            }
+        }
+
+
+
     public void updateFrom(EventUpdateRequest dto) {
+
         Optional.ofNullable(dto.getTitle()).ifPresent(t -> this.title = t);
         Optional.ofNullable(dto.getVenue()).ifPresent(v -> this.venue = v);
         Optional.ofNullable(dto.getDescription()).ifPresent(d -> this.description = d);
         Optional.ofNullable(dto.getStartDate()).ifPresent(sd -> this.startDate = sd);
         Optional.ofNullable(dto.getEndDate()).ifPresent(ed -> this.endDate = ed);
-    }
+        if (dto.getSchedules()!=null) {
+            Map<Long, Schedule> originalSchedule = schedules.stream()
+                    .collect(Collectors.toMap(Schedule::getId, Function.identity()));
+            for (ScheduleInfo schedule : dto.getSchedules()) {
+                if (schedule.getId() != null && originalSchedule.containsKey(schedule.getId())) {
+                    Schedule selectedSchedule = originalSchedule.remove(schedule.getId());
+                    validUpdateSchedule(selectedSchedule);
+                    selectedSchedule.updateFrom(schedule.getShowDate(), schedule.getShowTime(),schedule.getReservationStart(),schedule.getReservationEnd());
+                } else {
+                    Schedule newSchedule = Schedule.builder().showDate(schedule.getShowDate())
+                            .showTime(schedule.getShowTime())
+                            .reservationStart(schedule.getReservationStart())
+                            .reservationEnd(schedule.getReservationEnd())
+                            .build();
+                    newSchedule.setEvent(this);
+                    schedules.add(newSchedule);
+                }
+            }
+            for (Schedule removeTarget : originalSchedule.values()) {
+                schedules.remove(removeTarget);
+            }
+        }
 
+    }
 }

--- a/src/main/java/com/noljo/nolzo/event/service/EventService.java
+++ b/src/main/java/com/noljo/nolzo/event/service/EventService.java
@@ -10,6 +10,7 @@ import com.noljo.nolzo.global.upload.S3Uploader;
 import com.noljo.nolzo.schedule.dto.internal.ScheduleInfo;
 import com.noljo.nolzo.schedule.entity.Schedule;
 import com.noljo.nolzo.seat.service.SeatService;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -26,6 +29,7 @@ public class EventService {
     private final EventRepository eventRepository;
     private final SeatService seatService;
     private final S3Uploader s3Uploader;
+    private final EntityManager em;
 
     public Event getEvent(Long id) {
         return eventRepository.findById(id)
@@ -86,7 +90,17 @@ public class EventService {
 
     public EventResponse update(Long id, EventUpdateRequest dto) {
         Event original = getEvent(id);
+        Set<Long> originalSchedules = original.getSchedules().stream()
+                        .map(Schedule::getId)
+                                .collect(Collectors.toSet());
+
         original.updateFrom(dto);
+
+        em.flush();
+
+        original.getSchedules().stream()
+                .filter(schedule -> !originalSchedules.contains(schedule.getId()))
+                .forEach(schedule -> seatService.createSeats(schedule.getId()));
 
         return EventResponse.from(original);
     }

--- a/src/main/java/com/noljo/nolzo/event/service/EventService.java
+++ b/src/main/java/com/noljo/nolzo/event/service/EventService.java
@@ -88,15 +88,6 @@ public class EventService {
         Event original = getEvent(id);
         original.updateFrom(dto);
 
-        List<Schedule> schedules = original.getSchedules();
-        List<ScheduleInfo> updatedInfo = dto.getSchedule();
-
-        for (int i = 0; i < schedules.size(); i++) {
-            Schedule schedule = schedules.get(i);
-            ScheduleInfo info = updatedInfo.get(i);
-            schedule.updateFrom(info.getShowDate(), info.getShowTime());
-        }
-
         return EventResponse.from(original);
     }
 

--- a/src/main/java/com/noljo/nolzo/schedule/dto/internal/ScheduleInfo.java
+++ b/src/main/java/com/noljo/nolzo/schedule/dto/internal/ScheduleInfo.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ScheduleInfo {
+    private Long id;
     private LocalDate showDate;
     private LocalTime showTime;
     private LocalDateTime reservationStart;
@@ -19,5 +20,11 @@ public class ScheduleInfo {
         this.showTime=showTime;
         this.reservationStart=reservationStart;
         this.reservationEnd=reservationEnd;
+    }
+    public ScheduleInfo(LocalDate showDate, LocalTime showTime, LocalDateTime reservationStart, Long id){
+        this.showDate=showDate;
+        this.showTime=showTime;
+        this.reservationStart=reservationStart;
+        this.id=id;
     }
 }

--- a/src/main/java/com/noljo/nolzo/schedule/dto/internal/ScheduleInfo.java
+++ b/src/main/java/com/noljo/nolzo/schedule/dto/internal/ScheduleInfo.java
@@ -21,10 +21,11 @@ public class ScheduleInfo {
         this.reservationStart=reservationStart;
         this.reservationEnd=reservationEnd;
     }
-    public ScheduleInfo(LocalDate showDate, LocalTime showTime, LocalDateTime reservationStart, Long id){
+    public ScheduleInfo(LocalDate showDate, LocalTime showTime, LocalDateTime reservationStart,LocalDateTime reservationEnd, Long id){
         this.showDate=showDate;
         this.showTime=showTime;
         this.reservationStart=reservationStart;
+        this.reservationEnd=reservationEnd;
         this.id=id;
     }
 }

--- a/src/main/java/com/noljo/nolzo/schedule/entity/Schedule.java
+++ b/src/main/java/com/noljo/nolzo/schedule/entity/Schedule.java
@@ -50,8 +50,10 @@ public class Schedule {
         this.event = event;
     }
 
-    public void updateFrom(LocalDate showDate, LocalTime showTime) {
+    public void updateFrom(LocalDate showDate, LocalTime showTime,LocalDateTime reservationStart,LocalDateTime reservationEnd) {
         this.showDate = showDate;
         this.showTime = showTime;
+        this.reservationStart=reservationStart;
+        this.reservationEnd=reservationEnd;
     }
 }

--- a/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
@@ -142,12 +142,12 @@ class EventServiceTest {
         List<ScheduleResponse> updatedSchedules = eventService.findById(id).getSchedules();
 
         Assertions.assertThat(updatedSchedules)
-                .hasSameSizeAs(updateRequest.getSchedule());
+                .hasSameSizeAs(updateRequest.getSchedules());
         for (int i = 0; i < updatedSchedules.size(); i++) {
             Assertions.assertThat(updatedSchedules.get(i).getShowDate())
-                    .isEqualTo(updateRequest.getSchedule().get(i).getShowDate());
+                    .isEqualTo(updateRequest.getSchedules().get(i).getShowDate());
             Assertions.assertThat(updatedSchedules.get(i).getShowTime())
-                    .isEqualTo(updateRequest.getSchedule().get(i).getShowTime());
+                    .isEqualTo(updateRequest.getSchedules().get(i).getShowTime());
         }
     }
 

--- a/src/test/java/com/noljo/nolzo/support/fixture/EventFixture.java
+++ b/src/test/java/com/noljo/nolzo/support/fixture/EventFixture.java
@@ -15,23 +15,23 @@ import lombok.Getter;
 @Getter
 public enum EventFixture {
     캣츠("Cats", "서울 예술의 전당", "세계적으로 유명한 뮤지컬, 고양이들의 이야기를 그린 작품입니다.",
-            "https://example.com/cats.jpg", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 6, 30),
+            "https://example.com/cats.jpg", LocalDate.of(2024, 3, 1), LocalDate.of(2026, 6, 30),
             EventCategory.CONCERT, 180, 12, 5, 120
-            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2024, 2, 27, 12, 0)
+            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2026, 2, 27, 12, 0)
     ),
     캣츠2("Cats2", "서울 예술의 전당", "세계적으로 유명한 뮤지컬, 고양이들의 이야기를 그린 작품입니다.",
-            "https://example.com/cats.jpg", LocalDate.of(2024, 3, 1), LocalDate.of(2024, 6, 30),
+            "https://example.com/cats.jpg", LocalDate.of(2024, 3, 1), LocalDate.of(2026, 6, 30),
             EventCategory.CONCERT, 180, 12, 5, 120
-            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2024, 2, 27, 12, 0)),
+            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2026, 2, 27, 12, 0)),
     햄릿("Hamlet", "국립극장 해오름극장", "셰익스피어 4대 비극 중 하나인 '햄릿'의 현대적 재해석 공연입니다.",
-            "https://example.com/hamlet.jpg", LocalDate.of(2025, 7, 1), LocalDate.of(2025, 7, 15),
+            "https://example.com/hamlet.jpg", LocalDate.of(2024, 7, 1), LocalDate.of(2026, 7, 15),
             EventCategory.CONCERT, 150, 15, 4, 80
 
-            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2024, 2, 27, 12, 0)),
+            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2026, 2, 27, 12, 0)),
     햄릿일정("Hamlet", "국립극장 해오름극장", "셰익스피어 4대 비극 중 하나인 '햄릿'의 현대적 재해석 공연.",
-            "https://example.com/hamlet.jpg", LocalDate.of(2025, 7, 1), LocalDate.of(2025, 7, 15),
+            "https://example.com/hamlet.jpg", LocalDate.of(2024, 7, 1), LocalDate.of(2026, 7, 15),
             EventCategory.CONCERT, 150, 15, 4, 80
-            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2024, 2, 27, 12, 0));
+            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2026, 2, 27, 12, 0));
 
     private String title;
     private String venue;
@@ -96,9 +96,10 @@ public enum EventFixture {
                 .ageLimit(캣츠.ageLimit)
                 .schedules(List.of(
                         new ScheduleInfo(
-                                LocalDate.of(2024, 5, 10),
+                                LocalDate.of(2025, 5, 10),
                                 LocalTime.of(19, 30),
-                                null
+                                LocalDateTime.of(2023,6,25,11,0,0),
+                                LocalDateTime.of(2026,6,25,11,0,0)
                         )
                 ))
                 .build();
@@ -111,13 +112,12 @@ public enum EventFixture {
                 .description(캣츠2.description)
                 .startDate(캣츠2.startDate)
                 .endDate(캣츠2.endDate)
-                .reservationStart (캣츠2. reservationStart)
-                .reservationEnd(캣츠2.reservationEnd)
-                .schedule(List.of(
+                .schedules(List.of(
                         new ScheduleInfo(
-                                LocalDate.of(2024, 5, 12),
+                                LocalDate.of(2025, 5, 12),
                                 LocalTime.of(18, 0),
-                                null
+                                LocalDateTime.of(2025,6,25,11,0,0),
+                                LocalDateTime.of(2026,6,25,11,0,0)
                         )
                 ))
                 .build();
@@ -136,9 +136,10 @@ public enum EventFixture {
                 .ageLimit(햄릿.ageLimit)
                 .schedules(List.of(
                         new ScheduleInfo(
-                                LocalDate.of(2024, 5, 10),
+                                LocalDate.of(2025, 5, 10),
                                 LocalTime.of(19, 30),
-                                null
+                                LocalDateTime.of(2023,6,25,11,0,0),
+                                LocalDateTime.of(2026,6,25,11,0,0)
                         )
                 ))
                 .build();
@@ -157,9 +158,10 @@ public enum EventFixture {
                 .ageLimit(햄릿일정.ageLimit)
                 .schedules(List.of(
                         new ScheduleInfo(
-                                LocalDate.of(2024, 5, 10),
+                                LocalDate.of(2025, 5, 10),
                                 LocalTime.of(19, 30),
-                                null
+                                LocalDateTime.of(2023,6,25,11,0,0),
+                                LocalDateTime.of(2026,6,25,11,0,0)
                         )
                 ))
                 .build();

--- a/src/test/java/com/noljo/nolzo/support/fixture/ScheduleFixture.java
+++ b/src/test/java/com/noljo/nolzo/support/fixture/ScheduleFixture.java
@@ -21,6 +21,8 @@ public enum ScheduleFixture {
     }
 
     public static Schedule 공연_스케쥴(Event event) {
-        return new Schedule(공연스케쥴.showDate, 공연스케쥴.showTime, event, LocalDateTime.of(2025,6,25,11,0,0));
+        return new Schedule(공연스케쥴.showDate, 공연스케쥴.showTime, event,
+                LocalDateTime.of(2025,6,25,11,0,0),
+                LocalDateTime.of(2026,6,25,11,0,0));
     }
 }


### PR DESCRIPTION
## 📌 개요
예매시간, 공연시간에 맞춘 예외처리와 스케줄 수정, 추가가 가능
기존 스케줄의 id와 함께 입력시 스케줄 데이터만 수정.
null id의 스케줄 추가되어 요청시 스케줄 추가 및 좌석 할당.
기존 스케줄이 포함되지 않은 요청시 해당 스케줄 삭제 및 좌석 삭제.

## 🛠️ 작업 내용
- [ ] 변경 사항 요약
- [ ] 주요 변경 사항 설명
- [ ] 관련 이슈 번호 (`#142`)
### (소제목)



## 📌 차후 계획 (Optional)

업데이트 로직의 변경으로 프론트엔드 수정이 필요합니다.

---
close #142 