### PR TITLE
[Feature] 이벤트 리뷰 조회 기능에 페이징 적용

### DIFF
--- a/src/main/java/com/noljo/nolzo/review/controller/ReviewController.java
+++ b/src/main/java/com/noljo/nolzo/review/controller/ReviewController.java
@@ -1,11 +1,11 @@
 package com.noljo.nolzo.review.controller;
 
 import com.noljo.nolzo.auth.security.CustomUserDetails;
-import com.noljo.nolzo.review.dto.request.ReviewUpdateRequest;
-import com.noljo.nolzo.review.dto.response.EventReviewDetailsResponse;
-import com.noljo.nolzo.review.dto.response.ReviewUpdateResponse;
 import com.noljo.nolzo.review.dto.request.ReviewCreateRequest;
+import com.noljo.nolzo.review.dto.request.ReviewUpdateRequest;
+import com.noljo.nolzo.review.dto.response.EventReviewPageResponse;
 import com.noljo.nolzo.review.dto.response.ReviewResponse;
+import com.noljo.nolzo.review.dto.response.ReviewUpdateResponse;
 import com.noljo.nolzo.review.service.ReviewService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -47,8 +47,12 @@ public class ReviewController {
 
     @Transactional(readOnly = true)
     @GetMapping("/events/{eventId}")
-    public ResponseEntity<EventReviewDetailsResponse> getReviewsByEvent(@PathVariable Long eventId) {
-        EventReviewDetailsResponse response = reviewService.getReviewsByEventId(eventId);
+    public ResponseEntity<EventReviewPageResponse> getReviewsByEvent(
+            @PathVariable Long eventId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size
+    ) {
+        EventReviewPageResponse response = reviewService.getPagingReviewsByEventId(eventId, page, size);
         return ResponseEntity.ok(response);
     }
 
@@ -73,7 +77,7 @@ public class ReviewController {
 
     @DeleteMapping("/{reviewId}")
     public ResponseEntity<Void> deleteReview(
-            @AuthenticationPrincipal CustomUserDetails user, 
+            @AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long reviewId
     ) {
         reviewService.delete(user.getMemberId(), reviewId);

--- a/src/main/java/com/noljo/nolzo/review/dto/response/EventReviewPageResponse.java
+++ b/src/main/java/com/noljo/nolzo/review/dto/response/EventReviewPageResponse.java
@@ -1,0 +1,35 @@
+package com.noljo.nolzo.review.dto.response;
+
+import com.noljo.nolzo.review.entity.Review;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record EventReviewPageResponse(
+        double averageRating,
+        long totalReviewCount,
+        List<ReviewDetailResponse> reviews,
+        int currentPage,
+        int totalPages,
+        int pageSize,
+        boolean hasNext,
+        boolean hasPrevious
+) {
+    public static EventReviewPageResponse from(
+            Page<Review> reviewPage,
+            List<ReviewDetailResponse> reviewResponses,
+            double averageRating,
+            int page,
+            int size
+    ) {
+        return new EventReviewPageResponse(
+                averageRating,
+                reviewPage.getTotalElements(),
+                reviewResponses,
+                page,
+                reviewPage.getTotalPages(),
+                size,
+                reviewPage.hasNext(),
+                reviewPage.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/com/noljo/nolzo/review/dto/response/EventReviewPageResponse.java
+++ b/src/main/java/com/noljo/nolzo/review/dto/response/EventReviewPageResponse.java
@@ -14,7 +14,7 @@ public record EventReviewPageResponse(
         boolean hasNext,
         boolean hasPrevious
 ) {
-    public static EventReviewPageResponse from(
+    public static EventReviewPageResponse of(
             Page<Review> reviewPage,
             List<ReviewDetailResponse> reviewResponses,
             double averageRating,

--- a/src/main/java/com/noljo/nolzo/review/repository/ReviewRepository.java
+++ b/src/main/java/com/noljo/nolzo/review/repository/ReviewRepository.java
@@ -1,9 +1,13 @@
 package com.noljo.nolzo.review.repository;
 
 import com.noljo.nolzo.review.entity.Review;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     default Review getOrThrow(Long id) {
@@ -15,5 +19,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Optional<Review> findByMemberIdAndEventId(Long memberId, Long eventId);
 
-    List<Review> findByEventId(Long eventId);
+    Page<Review> findPageByEventId(Long eventId, Pageable pageable);
+
+    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.event.id = :eventId")
+    Double getAverageByEventId(@Param("eventId") Long eventId);
 }

--- a/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
+++ b/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
@@ -1,20 +1,23 @@
 package com.noljo.nolzo.review.service;
 
-import com.noljo.nolzo.review.dto.request.ReviewUpdateRequest;
-import com.noljo.nolzo.review.dto.response.EventReviewDetailsResponse;
-import com.noljo.nolzo.review.dto.response.ReviewDetailResponse;
-import com.noljo.nolzo.review.dto.response.ReviewUpdateResponse;
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.repository.EventRepository;
 import com.noljo.nolzo.member.entity.Member;
 import com.noljo.nolzo.member.repository.MemberRepository;
 import com.noljo.nolzo.reservation.repository.ReservationRepository;
 import com.noljo.nolzo.review.dto.request.ReviewCreateRequest;
+import com.noljo.nolzo.review.dto.request.ReviewUpdateRequest;
+import com.noljo.nolzo.review.dto.response.EventReviewPageResponse;
+import com.noljo.nolzo.review.dto.response.ReviewDetailResponse;
 import com.noljo.nolzo.review.dto.response.ReviewResponse;
+import com.noljo.nolzo.review.dto.response.ReviewUpdateResponse;
 import com.noljo.nolzo.review.entity.Review;
 import com.noljo.nolzo.review.repository.ReviewRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,7 +30,7 @@ public class ReviewService {
     private final MemberRepository memberRepository;
     private final ReservationRepository reservationRepository;
 
-    public ReviewResponse create(Long memberId, ReviewCreateRequest request){
+    public ReviewResponse create(Long memberId, ReviewCreateRequest request) {
         Member member = memberRepository.getOrThrow(memberId);
         Event event = eventRepository.getOrThrow(request.eventId());
 
@@ -63,12 +66,14 @@ public class ReviewService {
         return ReviewResponse.from(review);
     }
 
-    public EventReviewDetailsResponse getReviewsByEventId(Long eventId) {
-        List<ReviewDetailResponse> reviews  = findDetailReviewsByEvent(eventId);
-        double averageRating = getAverageRating(reviews);
-        return new EventReviewDetailsResponse(averageRating, reviews.size(), reviews);
+    public EventReviewPageResponse getPagingReviewsByEventId(Long eventId, int page, int size) {
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Review> reviewPage = reviewRepository.findPageByEventId(eventId, pageable);
+        var reviewResponses = getReviewDetailResponsesFromReviewPage(reviewPage);
+        Double averageRating = reviewRepository.getAverageByEventId(eventId);
+        return EventReviewPageResponse.from(reviewPage, reviewResponses, averageRating, page, size);
     }
-  
+
     public void delete(Long memberId, Long reviewId) {
         Review review = reviewRepository.getOrThrow(reviewId);
         validateReviewOwner(review, memberId);
@@ -81,7 +86,7 @@ public class ReviewService {
         }
     }
 
-    private void validateEventParticipation(Long memberId, Long eventId){
+    private void validateEventParticipation(Long memberId, Long eventId) {
         boolean isUsed = reservationRepository.findTicketStatusUsedByMemberId(memberId).stream()
                 .anyMatch(reservation -> reservation.getTickets().stream()
                         .anyMatch(ticket -> ticket.getSeat().getSchedule().getEvent().getId().equals(eventId)));
@@ -90,24 +95,17 @@ public class ReviewService {
         }
     }
 
-    private void validateAlreadyReviewed(Long memberId, Long eventId){
+    private void validateAlreadyReviewed(Long memberId, Long eventId) {
         boolean isAlreadyReviewed = reviewRepository.findByMemberIdAndEventId(memberId, eventId).isPresent();
         if (isAlreadyReviewed) {
             throw new IllegalStateException("이미 해당 이벤트에 대한 리뷰를 작성하였습니다.");
         }
     }
 
-    private List<ReviewDetailResponse> findDetailReviewsByEvent(Long eventId) {
-        return reviewRepository.findByEventId(eventId)
+    private List<ReviewDetailResponse> getReviewDetailResponsesFromReviewPage(Page<Review> reviewPage) {
+        return reviewPage.getContent()
                 .stream()
                 .map(ReviewDetailResponse::from)
                 .toList();
-    }
-
-    private static double getAverageRating(List<ReviewDetailResponse> reviews) {
-        return reviews.stream()
-                .mapToInt(ReviewDetailResponse::rating)
-                .average()
-                .orElse(0.0);
     }
 }

--- a/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
+++ b/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
@@ -69,7 +69,7 @@ public class ReviewService {
     public EventReviewPageResponse getPagingReviewsByEventId(Long eventId, int page, int size) {
         PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<Review> reviewPage = reviewRepository.findPageByEventId(eventId, pageable);
-        var reviewResponses = getReviewDetailResponsesFromReviewPage(reviewPage);
+        List<ReviewDetailResponse> reviewResponses = getReviewDetailResponsesFromReviewPage(reviewPage);
         Double averageRating = reviewRepository.getAverageByEventId(eventId);
         return EventReviewPageResponse.of(reviewPage, reviewResponses, averageRating, page, size);
     }

--- a/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
+++ b/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
@@ -71,7 +71,7 @@ public class ReviewService {
         Page<Review> reviewPage = reviewRepository.findPageByEventId(eventId, pageable);
         var reviewResponses = getReviewDetailResponsesFromReviewPage(reviewPage);
         Double averageRating = reviewRepository.getAverageByEventId(eventId);
-        return EventReviewPageResponse.from(reviewPage, reviewResponses, averageRating, page, size);
+        return EventReviewPageResponse.of(reviewPage, reviewResponses, averageRating, page, size);
     }
 
     public void delete(Long memberId, Long reviewId) {

--- a/src/test/java/com/noljo/nolzo/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/review/service/ReviewServiceTest.java
@@ -110,9 +110,9 @@ public class ReviewServiceTest {
         reviewRepository.save(review1);
         reviewRepository.save(review2);
 
-        var result = reviewService.getReviewsByEventId(event.getId());
+        var result = reviewService.getPagingReviewsByEventId(event.getId(), 5, 5);
 
-        assertThat(result.reviewCount()).isEqualTo(2);
+        assertThat(result.totalReviewCount()).isEqualTo(2);
         assertThat(result.averageRating()).isEqualTo((review1.getRating() + review2.getRating()) / 2.0);
     }
   


### PR DESCRIPTION
## 📌 개요
기존 이벤트의 모든 리뷰를 한 번에 조회하여 리뷰가 많을 경우 성능 저하 및 사용자 경험 저하
이벤트와 연관된 리뷰 목록을 조회할 때, 페이징 처리를 도입하였습니다.

## 🛠️ 작업 내용
- [ ] 변경 사항 요약
- [ ] 주요 변경 사항 설명
- [ ] 관련 이슈 번호 (`#141`)
### (소제목)
`GET /api/v1/reviews/events/{eventId}` 엔드포인트에 페이징 파라미터 추가
- `page`: 페이지 번호 (기본값: 0)
- `size`: 페이지당 리뷰 개수 (기본값: 5)
- `EventReviewPageResponse` DTO 추가로 페이징 정보 포함
  - 현재 페이지, 전체 페이지 수, 다음/이전 페이지 존재 여부 등
- 최신 리뷰순 정렬 (createdAt DESC)


## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

### 📌 기타 참고 사항
평균 평점 구하는 부분은 멘토링 이후 적절한 구현 방식을 고려해서 다시 리팩토링할 예정입니다.

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.
close #141 