### PR TITLE
[Feature] 이벤트 카테고리별 조회에 페이징 처리 적용

### DIFF
--- a/src/main/java/com/noljo/nolzo/event/controller/EventController.java
+++ b/src/main/java/com/noljo/nolzo/event/controller/EventController.java
@@ -7,6 +7,7 @@ import com.noljo.nolzo.event.entity.EventCategory;
 import com.noljo.nolzo.event.service.EventService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -30,9 +31,9 @@ public class EventController {
         return ResponseEntity.ok(eventService.save(dto,eventImage));
     }
 
-    @GetMapping(params = "category")
-    public ResponseEntity<List<EventResponse>> getEventByCategory(@RequestParam EventCategory category) {
-        return ResponseEntity.ok(eventService.findAllByCategory(category));
+    @GetMapping
+    public ResponseEntity<Slice<EventResponse>> getEventByCategory(@RequestParam EventCategory category, @RequestParam("page") int page) { // Pageable 객체를 파라미터로 추가
+        return ResponseEntity.ok(eventService.findAllByCategory(category, page));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/noljo/nolzo/event/controller/EventController.java
+++ b/src/main/java/com/noljo/nolzo/event/controller/EventController.java
@@ -32,7 +32,7 @@ public class EventController {
     }
 
     @GetMapping
-    public ResponseEntity<Slice<EventResponse>> getEventByCategory(@RequestParam EventCategory category, @RequestParam("page") int page) { // Pageable 객체를 파라미터로 추가
+    public ResponseEntity<Slice<EventResponse>> getEventByCategory(@RequestParam EventCategory category, @RequestParam("page") int page) {
         return ResponseEntity.ok(eventService.findAllByCategory(category, page));
     }
 

--- a/src/main/java/com/noljo/nolzo/event/dto/EventRequest.java
+++ b/src/main/java/com/noljo/nolzo/event/dto/EventRequest.java
@@ -11,9 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/noljo/nolzo/event/dto/EventResponse.java
+++ b/src/main/java/com/noljo/nolzo/event/dto/EventResponse.java
@@ -6,7 +6,6 @@ import com.noljo.nolzo.event.entity.EventCategory;
 import lombok.Builder;
 import lombok.Getter;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/noljo/nolzo/event/dto/EventUpdateRequest.java
+++ b/src/main/java/com/noljo/nolzo/event/dto/EventUpdateRequest.java
@@ -10,7 +10,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter

--- a/src/main/java/com/noljo/nolzo/event/dto/ReservationEvent.java
+++ b/src/main/java/com/noljo/nolzo/event/dto/ReservationEvent.java
@@ -2,11 +2,10 @@ package com.noljo.nolzo.event.dto;
 
 import com.noljo.nolzo.schedule.entity.Schedule;
 import com.noljo.nolzo.event.entity.Event;
-import lombok.Builder;
-import lombok.Getter;
-
 import java.time.LocalDate;
 import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
 
 @Builder
 @Getter
@@ -40,4 +39,3 @@ public class ReservationEvent {
                 .build();
     }
 }
-

--- a/src/main/java/com/noljo/nolzo/event/entity/Event.java
+++ b/src/main/java/com/noljo/nolzo/event/entity/Event.java
@@ -5,17 +5,13 @@ import com.noljo.nolzo.schedule.dto.internal.ScheduleInfo;
 import com.noljo.nolzo.schedule.entity.Schedule;
 import com.noljo.nolzo.global.BaseEntity;
 import jakarta.persistence.*;
-
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.cglib.core.Local;
-
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +48,6 @@ public class Event extends BaseEntity {
 
     private int ageLimit;
 
-
     @Column(nullable = false)
     private long viewCount = 0;
 
@@ -80,7 +75,6 @@ public class Event extends BaseEntity {
         schedule.setEvent(this);
     }
 
-
     public void addViewCount() {
         this.viewCount++;
     }
@@ -102,9 +96,7 @@ public class Event extends BaseEntity {
         }
     }
 
-
     public void updateFrom(EventUpdateRequest dto) {
-
         Optional.ofNullable(dto.getTitle()).ifPresent(t -> this.title = t);
         Optional.ofNullable(dto.getVenue()).ifPresent(v -> this.venue = v);
         Optional.ofNullable(dto.getDescription()).ifPresent(d -> this.description = d);
@@ -137,5 +129,4 @@ public class Event extends BaseEntity {
             schedules.add(newSchedule);
         }
     }
-
 }

--- a/src/main/java/com/noljo/nolzo/event/repository/EventRepository.java
+++ b/src/main/java/com/noljo/nolzo/event/repository/EventRepository.java
@@ -2,25 +2,23 @@ package com.noljo.nolzo.event.repository;
 
 import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.entity.EventCategory;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.Collection;
 import java.util.List;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findTop10ByEventCategoryOrderByViewCountDesc(EventCategory eventCategory);
 
-    List<Event> findAllByEventCategory(EventCategory eventCategory, Sort sort);
+    Slice<Event> findAllByEventCategory(EventCategory eventCategory, Pageable pageable);
 
     List<Event> findTop6ByOrderByViewCountDesc();
   
     List<Event> findByTitleContaining(String search);
 
     default Event getOrThrow(Long id) {
-        return findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이벤트입니다. (ID: " + id + ")"));
+        return findById(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이벤트입니다. (ID: " + id + ")"));
     }
 }

--- a/src/main/java/com/noljo/nolzo/event/service/EventService.java
+++ b/src/main/java/com/noljo/nolzo/event/service/EventService.java
@@ -7,11 +7,13 @@ import com.noljo.nolzo.event.entity.Event;
 import com.noljo.nolzo.event.entity.EventCategory;
 import com.noljo.nolzo.event.repository.EventRepository;
 import com.noljo.nolzo.global.upload.S3Uploader;
-import com.noljo.nolzo.schedule.dto.internal.ScheduleInfo;
 import com.noljo.nolzo.schedule.entity.Schedule;
 import com.noljo.nolzo.seat.service.SeatService;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +28,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class EventService {
 
+    private static final int SIZE = 12;
+    private static final String SORT_BY_DATE = "createdAt";
     private final EventRepository eventRepository;
     private final SeatService seatService;
     private final S3Uploader s3Uploader;
@@ -44,10 +48,10 @@ public class EventService {
     }
 
     @Transactional(readOnly = true)
-    public List<EventResponse> findAllByCategory(EventCategory eventCategory) {
-        return eventRepository.findAllByEventCategory(eventCategory, Sort.by(Sort.Direction.DESC, "createdAt")).stream()
-                .map(EventResponse::from)
-                .toList();
+    public Slice<EventResponse> findAllByCategory(EventCategory eventCategory, int page) {
+        Pageable pageable = PageRequest.of(page, SIZE, Sort.by(Sort.Direction.DESC, SORT_BY_DATE));
+        Slice<Event> events = eventRepository.findAllByEventCategory(eventCategory, pageable);
+        return events.map(EventResponse::from);
     }
 
     public EventResponse save(EventRequest dto, MultipartFile image) {

--- a/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/event/service/EventServiceTest.java
@@ -14,6 +14,7 @@ import com.noljo.nolzo.support.fixture.FileFixture;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDate;
 import java.util.List;
@@ -46,7 +47,6 @@ class EventServiceTest {
 
     @Test
     void 개별_이벤트를_조회할_수_있다() {
-
         EventRequest dto = EventFixture.캣츠dto();
 
         EventResponse response = eventService.save(dto, image);
@@ -57,29 +57,8 @@ class EventServiceTest {
 
     @Test
     void 제목에_검색어가_포함된_이벤트만_조회된다() {
-        Event event1 = eventRepository.save(Event.builder()
-                .title("셜록홈즈: 블러디 게임")
-                .venue("LG아트센터 서울")
-                .description("정체불명의 연쇄 살인 사건을 둘러싼 셜록의 추리와 심리전")
-                .posterImageUrl("http://image.url/sherlock-bloody.jpg")
-                .startDate(LocalDate.of(2025, 11, 5))
-                .endDate(LocalDate.of(2025, 12, 20))
-                .eventCategory(EventCategory.MUSICAL)
-                .runtime(155)
-                .ageLimit(15)
-                .build());
-
-        Event event2 = eventRepository.save(Event.builder()
-                .title("셜록홈즈: 앤더슨가의 비밀")
-                .venue("광림아트센터 BBCH홀")
-                .description("셜록 홈즈와 왓슨이 앤더슨 가문의 미스터리를 파헤치는 이야기")
-                .posterImageUrl("http://image.url/sherlock-anderson.jpg")
-                .startDate(LocalDate.of(2025, 10, 15))
-                .endDate(LocalDate.of(2025, 12, 20))
-                .eventCategory(EventCategory.MUSICAL)
-                .runtime(155)
-                .ageLimit(15)
-                .build());
+        Event event1 = eventRepository.save(EventFixture.셜록_블러디());
+        Event event2 = eventRepository.save(EventFixture.셜록_앤더슨());
 
         List<EventResponse> result = eventService.searchEventList("셜록");
 
@@ -90,18 +69,20 @@ class EventServiceTest {
     }
 
     @Test
-    void 카테고리별_이벤트를_조회할_수_있다() {
-        EventRequest concertEvent = EventFixture.캣츠dto();
-        EventRequest hamletEvent = EventFixture.햄릿dto();
-        eventService.save(concertEvent, image);
-        eventService.save(hamletEvent, image);
+    void 카테고리별_페이징_처리_및_이벤트_조회_테스트() {
+        EventRequest dto2 = EventFixture.셜록_블러디_dto();
+        EventResponse response2 = eventService.save(dto2, image);
 
-        List<EventResponse> concertEvents = eventService.findAllByCategory(EventCategory.CONCERT);
+        EventRequest dto3 = EventFixture.셜록_앤더슨_dto();
+        EventResponse response3 = eventService.save(dto3, image);
 
-        Assertions.assertThat(concertEvents).hasSize(2);
-        Assertions.assertThat(concertEvents)
-                .extracting("eventCategory")
-                .containsOnly(EventCategory.CONCERT);
+        Slice<EventResponse> result = eventService.findAllByCategory(EventCategory.MUSICAL, 0);
+
+        Assertions.assertThat(result.getContent())
+                .hasSize(2)
+                .allSatisfy(event -> Assertions.assertThat(event.getEventCategory()).isEqualTo(EventCategory.MUSICAL));
+
+        Assertions.assertThat(result.hasNext()).isFalse();
     }
 
     @Test
@@ -109,9 +90,9 @@ class EventServiceTest {
         EventRequest concertEvent = EventFixture.캣츠dto();
         eventService.save(concertEvent, image);
 
-        List<EventResponse> otherEvents = eventService.findAllByCategory(EventCategory.MUSICAL);
+        Slice<EventResponse> otherEvents = eventService.findAllByCategory(EventCategory.MUSICAL, 0);
 
-        Assertions.assertThat(otherEvents).isEmpty();
+        Assertions.assertThat(otherEvents.getContent()).isEmpty();
     }
 
     @Test
@@ -188,8 +169,7 @@ class EventServiceTest {
         eventRepository.save(cats);
         eventRepository.save(hamlet);
 
-        List<EventResponse> result =
-                eventService.getTop10ByCategory(EventCategory.CONCERT);
+        List<EventResponse> result = eventService.getTop10ByCategory(EventCategory.CONCERT);
 
         Assertions.assertThat(result).hasSize(2);
         Assertions.assertThat(result.get(0).getId()).isEqualTo(hamlet.getId());

--- a/src/test/java/com/noljo/nolzo/support/fixture/EventFixture.java
+++ b/src/test/java/com/noljo/nolzo/support/fixture/EventFixture.java
@@ -22,16 +22,28 @@ public enum EventFixture {
     캣츠2("Cats2", "서울 예술의 전당", "세계적으로 유명한 뮤지컬, 고양이들의 이야기를 그린 작품입니다.",
             "https://example.com/cats.jpg", LocalDate.of(2024, 3, 1), LocalDate.of(2026, 6, 30),
             EventCategory.CONCERT, 180, 12, 5, 120
-            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2026, 2, 27, 12, 0)),
+            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2026, 2, 27, 12, 0)
+    ),
     햄릿("Hamlet", "국립극장 해오름극장", "셰익스피어 4대 비극 중 하나인 '햄릿'의 현대적 재해석 공연입니다.",
             "https://example.com/hamlet.jpg", LocalDate.of(2024, 7, 1), LocalDate.of(2026, 7, 15),
             EventCategory.CONCERT, 150, 15, 4, 80
-
-            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2026, 2, 27, 12, 0)),
+            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2026, 2, 27, 12, 0)
+    ),
     햄릿일정("Hamlet", "국립극장 해오름극장", "셰익스피어 4대 비극 중 하나인 '햄릿'의 현대적 재해석 공연.",
             "https://example.com/hamlet.jpg", LocalDate.of(2024, 7, 1), LocalDate.of(2026, 7, 15),
             EventCategory.CONCERT, 150, 15, 4, 80
-            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2026, 2, 27, 12, 0));
+            , LocalDateTime.of(2024, 2, 25, 12, 0), LocalDateTime.of(2026, 2, 27, 12, 0)
+    ),
+    셜록_블러디("셜록홈즈: 블러디 게임", "LG아트센터 서울", "정체불명의 연쇄 살인 사건을 둘러싼 셜록의 추리와 심리전",
+            "http://image.url/sherlock-bloody.jpg", LocalDate.of(2025, 11, 5),
+            LocalDate.of(2025, 12, 20), EventCategory.MUSICAL, 155, 15, 0, 0,
+            LocalDateTime.of(2025, 10, 1, 12, 0), LocalDateTime.of(2025, 10, 30, 12, 0)
+    ),
+    셜록_앤더슨("셜록홈즈: 앤더슨가의 비밀", "광림아트센터 BBCH홀", "셜록 홈즈와 왓슨이 앤더슨 가문의 미스터리를 파헤치는 이야기",
+            "http://image.url/sherlock-anderson.jpg", LocalDate.of(2025, 10, 15),
+            LocalDate.of(2025, 12, 20), EventCategory.MUSICAL, 155, 15, 0, 0,
+            LocalDateTime.of(2025, 9, 1, 12, 0), LocalDateTime.of(2025, 9, 30, 12, 0)
+    );
 
     private String title;
     private String venue;
@@ -45,10 +57,8 @@ public enum EventFixture {
     private int ageLimit;
     private int rating;
     private int reviewCount;
-
     private LocalDateTime reservationStart;
     private LocalDateTime reservationEnd;
-
 
     EventFixture(String title, String venue, String description, String posterImageUrl,
                  LocalDate startDate, LocalDate endDate,
@@ -80,6 +90,18 @@ public enum EventFixture {
     public static Event 햄릿() {
         Event event = new Event(null, 햄릿.title, 햄릿.venue, 햄릿.description, 햄릿.posterImageUrl,
                 햄릿.startDate, 햄릿.endDate, 햄릿.eventCategory, 햄릿.runtime, 햄릿.ageLimit);
+        return event;
+    }
+
+    public static Event 셜록_블러디() {
+        Event event = new Event(null, 셜록_블러디.title, 셜록_블러디.venue, 셜록_블러디.description, 셜록_블러디.posterImageUrl,
+                셜록_블러디.startDate, 셜록_블러디.endDate, 셜록_블러디.eventCategory, 셜록_블러디.runtime, 셜록_블러디.ageLimit);
+        return event;
+    }
+
+    public static Event 셜록_앤더슨() {
+        Event event = new Event(null, 셜록_앤더슨.title, 셜록_앤더슨.venue, 셜록_앤더슨.description, 셜록_앤더슨.posterImageUrl,
+                셜록_앤더슨.startDate, 셜록_앤더슨.endDate, 셜록_앤더슨.eventCategory, 셜록_앤더슨.runtime, 셜록_앤더슨.ageLimit);
         return event;
     }
 
@@ -162,6 +184,50 @@ public enum EventFixture {
                                 LocalTime.of(19, 30),
                                 LocalDateTime.of(2023,6,25,11,0,0),
                                 LocalDateTime.of(2026,6,25,11,0,0)
+                        )
+                ))
+                .build();
+    }
+
+    public static EventRequest 셜록_블러디_dto() {
+        return EventRequest.builder()
+                .title(셜록_블러디.title)
+                .venue(셜록_블러디.venue)
+                .description(셜록_블러디.description)
+                .posterImageUrl(셜록_블러디.posterImageUrl)
+                .startDate(셜록_블러디.startDate)
+                .endDate(셜록_블러디.endDate)
+                .eventCategory(셜록_블러디.eventCategory)
+                .runtime(셜록_블러디.runtime)
+                .ageLimit(셜록_블러디.ageLimit)
+                .schedules(List.of(
+                        new ScheduleInfo(
+                                LocalDate.of(2025, 11, 6),
+                                LocalTime.of(19, 0),
+                                LocalDateTime.of(2025, 10, 1, 12, 0),
+                                LocalDateTime.of(2025, 10, 30, 12, 0)
+                        )
+                ))
+                .build();
+    }
+
+    public static EventRequest 셜록_앤더슨_dto() {
+        return EventRequest.builder()
+                .title(셜록_앤더슨.title)
+                .venue(셜록_앤더슨.venue)
+                .description(셜록_앤더슨.description)
+                .posterImageUrl(셜록_앤더슨.posterImageUrl)
+                .startDate(셜록_앤더슨.startDate)
+                .endDate(셜록_앤더슨.endDate)
+                .eventCategory(셜록_앤더슨.eventCategory)
+                .runtime(셜록_앤더슨.runtime)
+                .ageLimit(셜록_앤더슨.ageLimit)
+                .schedules(List.of(
+                        new ScheduleInfo(
+                                LocalDate.of(2025, 10, 16),
+                                LocalTime.of(19, 30),
+                                LocalDateTime.of(2025, 9, 1, 12, 0),
+                                LocalDateTime.of(2025, 9, 30, 12, 0)
                         )
                 ))
                 .build();


### PR DESCRIPTION
## 📌 개요
이벤트 카테고리별 조회 시, 이벤트 수가 많아질 경우를 대비해 Slice를 이용한 페이징 처리 도입

## 🛠️ 작업 내용
- [x]  Slice를 이용한 카테고리별 이벤트 조회 페이징 처리 적용
- [x]  목데이터 20개를 활용한 HTTP 응답 테스트 수행
- [x]  페이징 기능에 대한 테스트 코드 작성 및 실행 완료
- [x]  관련 이슈 번호 (#143)

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)
<img width="413" alt="스크린샷 2025-07-09 오후 6 11 28" src="https://github.com/user-attachments/assets/97e405fd-e530-43ad-86f6-c4023ceeca83" />

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.