### PR TITLE
[Fix] 평균 평점 조회 시 null일 경우 0을 반환하도록 수정

### DIFF
--- a/src/main/java/com/noljo/nolzo/review/repository/ReviewRepository.java
+++ b/src/main/java/com/noljo/nolzo/review/repository/ReviewRepository.java
@@ -21,6 +21,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Page<Review> findPageByEventId(Long eventId, Pageable pageable);
 
-    @Query("SELECT AVG(r.rating) FROM Review r WHERE r.event.id = :eventId")
+    @Query("SELECT IFNULL(AVG(r.rating), 0.0) FROM Review r WHERE r.event.id = :eventId")
     Double getAverageByEventId(@Param("eventId") Long eventId);
 }


### PR DESCRIPTION
## 📌 개요
이벤트에 해당하는 리뷰가 없을 때 평균 평점이 null로 반환되어 발생하는 오류를 수정

## 🛠️ 작업 내용
- [ ] 변경 사항 요약
- [ ] 주요 변경 사항 설명
- [ ] 관련 이슈 번호 (`#153`)
- getAverageByEventId 쿼리에 IFNULL 함수 추가
- 리뷰가 없는 경우 0.0을 반환하도록 처리

## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.
close #153 