### PR TITLE
[Refactor] 많은 사용자들의 좌석 조회 성능 개선

### DIFF
--- a/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
+++ b/src/main/java/com/noljo/nolzo/reservation/controller/ReservationController.java
@@ -31,7 +31,6 @@ public class ReservationController {
     }
 
     @PostMapping("/{eventId}")
-
     public ResponseEntity<EventDateTimeResponse> chooseEventDateTime(@PathVariable Long eventId,
                                                                      @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate selectDate,
                                                                      @RequestParam @DateTimeFormat(pattern = "HH:mm:ss") LocalTime selectTime) {
@@ -91,7 +90,7 @@ public class ReservationController {
     @DeleteMapping("/reservation/{reservationId}")
     public ResponseEntity<ReservationCancelResponse> cancelReservation(
             @AuthenticationPrincipal(expression = "memberId") Long memberId,
-            @PathVariable Long reservationId){
-        return ResponseEntity.ok(reservationService.cancelReservationById(memberId,reservationId));
+            @PathVariable Long reservationId) {
+        return ResponseEntity.ok(reservationService.cancelReservationById(memberId, reservationId));
     }
 }

--- a/src/main/java/com/noljo/nolzo/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/noljo/nolzo/schedule/repository/ScheduleRepository.java
@@ -1,8 +1,10 @@
 package com.noljo.nolzo.schedule.repository;
 
 import com.noljo.nolzo.schedule.entity.Schedule;
+import com.noljo.nolzo.seat.dto.SeatResponse;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -22,4 +24,19 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("showDate") LocalDate showDate,
             @Param("showTime") LocalTime showTime
     );
+
+    @Query("""
+    SELECT new com.noljo.nolzo.seat.dto.SeatResponse(se.id, se.rowName, se.seatNumber, se.seatSection, se.floor, se.price, se.status)
+    FROM Schedule s
+    JOIN s.seats se
+    WHERE s.event.id = :eventId
+    AND s.showDate = :showDate
+    AND s.showTime = :showTime
+    """)
+    List<SeatResponse> findSeatResponsesBySchedule(
+            @Param("eventId") Long eventId,
+            @Param("showDate") LocalDate showDate,
+            @Param("showTime") LocalTime showTime
+    );
+
 }

--- a/src/main/java/com/noljo/nolzo/seat/service/SeatService.java
+++ b/src/main/java/com/noljo/nolzo/seat/service/SeatService.java
@@ -84,11 +84,8 @@ public class SeatService {
 
     @Transactional(readOnly = true)
     public List<SeatResponse> findSeats(Long eventId, String date, String time) {
-        Schedule schedule = findScheduleByEventIdWithDate(eventId, date, time);
-
-        return schedule.getSeats().stream()
-                .map(SeatResponse::from)
-                .toList();
+        return scheduleRepository.findSeatResponsesBySchedule(
+                eventId, LocalDate.parse(date), LocalTime.parse(time));
     }
 
     private Schedule findScheduleByEventIdWithDate(Long eventId, String date, String time) {


### PR DESCRIPTION
## 🛠️ 작업 내용
- [x] 변경 사항 요약
- [x] 주요 변경 사항 설명
- [x] 관련 이슈 번호 (`#155`)

## 📌 개요

- 기존 로직: 인기 공연 예매를 위해 다수의 사용자가 좌석을 조회하는 시나리오에서, 성능 저하가 발생하였습니다. 원인은, 한 번의 좌석 조회 요청마다 전체 좌석과 스케줄을 조회하는 방식이었고, 데이터베이스에서 불필요한 데이터도 함께 로드되는 문제점이 있었습니다.

- 개선된 로직: 필요한 데이터만 조회하도록 쿼리 수정 및 **Projection** 사용을 통해, 불필요한 데이터 로드를 줄였고, 데이터베이스와의 효율적인 통신을 구현했습니다. 이를 통해 조회 속도 향상 및 메모리 사용 최적화를 목표로 했습니다.
--------

### 성능 문제

- 문제 발생 시나리오:

```
10회부터 200회까지는 응답 시간이 크게 변하지 않았지만, 400회 이후로 응답 시간이 급격하게 길어졌습니다.

이는 서버에 과도한 부하가 걸리면서 응답 속도가 지연되는 문제로 보입니다.
```

### 성능 개선 후:
```
다수의 사용자가 요청을 보내는 상황에서, 성능 저하가 최소화되었습니다.

전체 데이터를 조회하지 않고, 필요한 값만 가져오는 방식으로 리팩토링하여 응답 시간이 일정하게 유지되었습니다.
```
-----------

### 성능 개선의 원인 및 효과

- 쿼리 최적화:

```
기존에는 전체 Schedule과 연관된 Seat 정보를 로드했으나, 개선된 로직에서는 필요한 정보만을 DTO로 매핑하여 불필요한 데이터를 줄였습니다.

데이터베이스와의 통신 최적화로, 불필요한 I/O를 줄일 수 있었습니다.
```

- 메모리 사용 최적화:

```
기존의 Schedule 및 Seat 객체를 모두 로드하는 방식에서, SeatResponse와 같은 DTO를 사용하여 메모리 효율성을 높였습니다.

불필요한 객체를 생성하지 않음으로써, 메모리 사용이 최적화되었습니다.
```
---------
## 결론

- 기존 문제: 인기 공연 예매 시, 다수의 사용자가 좌석을 조회할 때 응답 시간이 급격히 지연됨.

- 개선 후: 불필요한 데이터를 로드하지 않고 필요한 정보만 조회하여, 성능 최적화 및 메모리 효율성 개선.

- 결과: 응답 시간이 일정하게 유지되며, 서버에 과도한 부하가 발생하지 않도록 최적화되었습니다. 또한 응답시간을 50% 빨라지도록 개선했습니다.

-------
* (작업한 코드에 대한 자세한 설명해주세요. 필요하다면 이미지나 표를 첨부해주세요)

### 기존 성능
<img width="970" height="326" alt="image" src="https://github.com/user-attachments/assets/6b9b9b94-0464-4de8-ba30-8a402b07a21a" />


### Fetch Join을 통한 개선

#### **개선 코드**
```java
@Query("""
    SELECT s FROM Schedule s
    JOIN FETCH s.seats
    WHERE s.event.id = :eventId
    AND s.showDate = :showDate
    AND s.showTime = :showTime
    """)
    Optional<Schedule> findByEventIdAndShowDateAndShowTime(
            @Param("eventId") Long eventId,
            @Param("showDate") LocalDate showDate,
            @Param("showTime") LocalTime showTime
    );
```

#### **개선 결과**

<img width="970" height="340" alt="image" src="https://github.com/user-attachments/assets/4a77294a-8a35-439a-b229-cd3f28601421" />


### Projection을 통한 개선

#### **개선 코드**
```java
@Query("""
    SELECT new com.noljo.nolzo.seat.dto.SeatResponse(se.id, se.rowName, se.seatNumber, se.seatSection, se.floor, se.price, se.status)
    FROM Schedule s
    JOIN s.seats se
    WHERE s.event.id = :eventId
    AND s.showDate = :showDate
    AND s.showTime = :showTime
    """)
    List<SeatResponse> findSeatResponsesBySchedule(
            @Param("eventId") Long eventId,
            @Param("showDate") LocalDate showDate,
            @Param("showTime") LocalTime showTime
    );
```

#### **개선 결과**
<img width="970" height="340" alt="image" src="https://github.com/user-attachments/assets/4fd56a8e-5a55-47d5-98aa-c5c144cfa7c1" />
------

## 각 방법의 장단점

#### 1. 기존 JPQL 쿼리 (엔티티 조회)

장점:
```
엔티티 전체 조회: 엔티티와 관련된 모든 데이터를 조회할 수 있습니다.

엔티티 객체에 대한 작업 가능: Schedule 및 그에 관련된 Seat 엔티티에 대해 여러 처리가 가능하고, 해당 객체들을 자유롭게 다룰 수 있습니다.
```

단점:
```
불필요한 데이터 로드: 전체 엔티티를 조회하게 되므로, 필요한 데이터만 가져오는 것보다 많은 데이터를 로드하게 됩니다. 예를 들어, Schedule 엔티티가 매우 크거나, Seat 엔티티가 많이 있을 경우, 비효율적인 성능을 보일 수 있습니다.

불필요한 연관 엔티티까지 조회: Schedule 엔티티의 필드를 모두 사용하지 않더라도 연관된 Seat 엔티티들을 모두 로드하게 되어 메모리 사용이 커질 수 있습니다.
```
#### 2. Fetch Join

장점: 
```
하나의 쿼리로 데이터를 로드: 연관된 엔티티들을 한 번에 로드하므로 추가적인 쿼리 실행을 줄일 수 있습니다. 예를 들어, Event와 연관된 Seat들을 조회할 때, Fetch Join을 사용하면 Seat에 대해 추가적인 쿼리를 날리지 않습니다.

N+1 문제 해결: N+1 문제를 해결하는 데 유용합니다. N+1 문제는 부모 엔티티를 조회할 때 자식 엔티티가 반복적으로 쿼리되는 현상입니다.
```

단점:
```
많은 데이터 로딩: Fetch Join을 사용하면 연관된 모든 엔티티를 한 번에 로드하므로, 불필요한 데이터를 많이 로딩할 수 있습니다. 이로 인해 메모리 사용량이 커질 수 있고, 실제로 필요하지 않은 데이터까지 로딩될 수 있습니다.

복잡한 쿼리: 연관된 엔티티가 많을수록 쿼리가 복잡해지며, 성능 저하를 유발할 수 있습니다.
```

#### 3. Projection

장점:
```
필요한 데이터만 로딩: Projection을 사용하면 불필요한 엔티티의 필드를 로딩하지 않고, 필요한 데이터만 로드합니다. 이로 인해 성능이 최적화되고, 메모리 사용량을 줄일 수 있습니다.

읽기 전용 데이터 최적화: 조회용 데이터만 필요한 경우, Projection은 엔티티의 변경을 추적하지 않기 때문에 더 효율적입니다.

쿼리 성능 향상: 필요한 데이터만 조회하므로, 불필요한 데이터 로딩을 줄여 쿼리 성능이 향상됩니다.
```

단점:
```
복잡한 쿼리 작성: 여러 필드를 DTO로 매핑하기 위해 @Query 어노테이션을 사용해야 할 때, 쿼리 작성이 복잡할 수 있습니다.

연관된 엔티티를 처리하기 어려움: Projection 방식은 연관된 엔티티를 쉽게 로딩하지 않기 때문에, 복잡한 연관 관계를 효율적으로 처리하기 위해 추가적인 조치가 필요할 수 있습니다.
```
-------

## 그래서 어떤 상황에서 무엇을 사용할 것인가?
### Fetch Join:

```
연관된 엔티티들을 반드시 모두 조회해야 하는 경우 사용합니다. 예를 들어, Order와 OrderItem을 조회할 때, OrderItem에 대한 추가적인 쿼리가 필요 없다면 Fetch Join을 사용하면 좋습니다.

N+1 문제가 발생할 수 있는 경우 Fetch Join을 통해 문제를 해결할 수 있습니다.
```

### Projection:

```
데이터의 일부분만 필요한 경우 Projection을 사용하여 쿼리를 최적화합니다. 예를 들어, Seat 정보에서 id, rowName, seatNumber만 필요할 때 Projection을 사용하여 성능을 최적화할 수 있습니다.

불필요한 데이터를 로드하지 않으므로 메모리와 성능을 효율적으로 관리할 수 있습니다.
```
----

## 결론

- **Fetch Join**은 연관된 모든 데이터를 한 번에 로드하려는 경우 유용하지만, 데이터가 많을 경우 성능과 메모리 문제를 일으킬 수 있습니다.

- **Projection**은 필요한 데이터만 조회하여 성능을 최적화할 수 있으며, 복잡한 연관 관계를 관리할 때 유리합니다.




## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)

close: #155 