### PR TITLE
[Refactor] 이벤트 리뷰 조회 성능 개선

### DIFF
--- a/src/main/java/com/noljo/nolzo/event/entity/Event.java
+++ b/src/main/java/com/noljo/nolzo/event/entity/Event.java
@@ -51,11 +51,14 @@ public class Event extends BaseEntity {
     @Column(nullable = false)
     private long viewCount = 0;
 
+    private double averageRating = 0.0;
+
     @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Schedule> schedules = new ArrayList<>();
 
     @Builder
-    public Event(Long id, String title, String venue, String description, String posterImageUrl, LocalDate startDate, LocalDate endDate,
+    public Event(Long id, String title, String venue, String description, String posterImageUrl, LocalDate startDate,
+                 LocalDate endDate,
                  EventCategory eventCategory, int runtime, int ageLimit) {
         this.id = id;
         this.title = title;
@@ -77,6 +80,10 @@ public class Event extends BaseEntity {
 
     public void addViewCount() {
         this.viewCount++;
+    }
+
+    public void updateAverageRating(double rating) {
+        this.averageRating = rating;
     }
 
     public void validUpdateSchedule(Schedule dto) {
@@ -106,7 +113,7 @@ public class Event extends BaseEntity {
             Map<Long, Schedule> originalSchedule = schedules.stream()
                     .collect(Collectors.toMap(Schedule::getId, Function.identity()));
             for (ScheduleInfo schedule : dto.getSchedules()) {
-                manageSchedule(schedule,originalSchedule);
+                manageSchedule(schedule, originalSchedule);
             }
             for (Schedule removeTarget : originalSchedule.values()) {
                 schedules.remove(removeTarget);
@@ -118,7 +125,8 @@ public class Event extends BaseEntity {
         if (schedule.getId() != null && originalSchedule.containsKey(schedule.getId())) {
             Schedule selectedSchedule = originalSchedule.remove(schedule.getId());
             validUpdateSchedule(selectedSchedule);
-            selectedSchedule.updateFrom(schedule.getShowDate(), schedule.getShowTime(), schedule.getReservationStart(), schedule.getReservationEnd());
+            selectedSchedule.updateFrom(schedule.getShowDate(), schedule.getShowTime(), schedule.getReservationStart(),
+                    schedule.getReservationEnd());
         } else {
             Schedule newSchedule = Schedule.builder().showDate(schedule.getShowDate())
                     .showTime(schedule.getShowTime())

--- a/src/main/java/com/noljo/nolzo/review/entity/Review.java
+++ b/src/main/java/com/noljo/nolzo/review/entity/Review.java
@@ -8,8 +8,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = @Index(name = "idx_review_event_created", columnList = "event_id, created_at DESC"))
 public class Review extends BaseEntity {
 
     @Id

--- a/src/main/java/com/noljo/nolzo/review/repository/ReviewRepository.java
+++ b/src/main/java/com/noljo/nolzo/review/repository/ReviewRepository.java
@@ -19,7 +19,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Optional<Review> findByMemberIdAndEventId(Long memberId, Long eventId);
 
-    Page<Review> findPageByEventId(Long eventId, Pageable pageable);
+    @Query(value = "SELECT r FROM Review r JOIN FETCH r.member WHERE r.event.id = :eventId",
+            countQuery = "SELECT count(r) FROM Review r WHERE r.event.id = :eventId")
+    Page<Review> findPageByEventId(@Param("eventId") Long eventId, Pageable pageable);
 
     @Query("SELECT IFNULL(AVG(r.rating), 0.0) FROM Review r WHERE r.event.id = :eventId")
     Double getAverageByEventId(@Param("eventId") Long eventId);

--- a/src/main/java/com/noljo/nolzo/review/scheduler/ReviewAverageRatingScheduler.java
+++ b/src/main/java/com/noljo/nolzo/review/scheduler/ReviewAverageRatingScheduler.java
@@ -1,0 +1,36 @@
+package com.noljo.nolzo.review.scheduler;
+
+import com.noljo.nolzo.event.entity.Event;
+import com.noljo.nolzo.event.repository.EventRepository;
+import com.noljo.nolzo.review.repository.ReviewRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class ReviewAverageRatingScheduler {
+
+    private final EventRepository eventRepository;
+    private final ReviewRepository reviewRepository;
+
+    @EventListener(ApplicationReadyEvent.class)
+
+    public void initializeEventAverageRatings() {
+        updateEventAverageRate();
+    }
+
+    @Scheduled(fixedRate = 30 * 60 * 1000)
+    public void updateEventAverageRate() {
+        List<Event> events = eventRepository.findAll();
+        events.forEach(event -> {
+            double averageRating = reviewRepository.getAverageByEventId(event.getId());
+            event.updateAverageRating(averageRating);
+        });
+    }
+}

--- a/src/main/java/com/noljo/nolzo/review/scheduler/ReviewAverageRatingScheduler.java
+++ b/src/main/java/com/noljo/nolzo/review/scheduler/ReviewAverageRatingScheduler.java
@@ -16,16 +16,16 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ReviewAverageRatingScheduler {
 
+    private static final long THIRTY_MINUTES = 10 * 60 * 1000L;
     private final EventRepository eventRepository;
     private final ReviewRepository reviewRepository;
 
     @EventListener(ApplicationReadyEvent.class)
-
     public void initializeEventAverageRatings() {
         updateEventAverageRate();
     }
 
-    @Scheduled(fixedRate = 30 * 60 * 1000)
+    @Scheduled(fixedRate = THIRTY_MINUTES)
     public void updateEventAverageRate() {
         List<Event> events = eventRepository.findAll();
         events.forEach(event -> {

--- a/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
+++ b/src/main/java/com/noljo/nolzo/review/service/ReviewService.java
@@ -70,8 +70,8 @@ public class ReviewService {
         PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<Review> reviewPage = reviewRepository.findPageByEventId(eventId, pageable);
         List<ReviewDetailResponse> reviewResponses = getReviewDetailResponsesFromReviewPage(reviewPage);
-        Double averageRating = reviewRepository.getAverageByEventId(eventId);
-        return EventReviewPageResponse.of(reviewPage, reviewResponses, averageRating, page, size);
+        Event event = eventRepository.getOrThrow(eventId);
+        return EventReviewPageResponse.of(reviewPage, reviewResponses, event.getAverageRating(), page, size);
     }
 
     public void delete(Long memberId, Long reviewId) {

--- a/src/test/java/com/noljo/nolzo/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/noljo/nolzo/domain/review/service/ReviewServiceTest.java
@@ -113,7 +113,6 @@ public class ReviewServiceTest {
         var result = reviewService.getPagingReviewsByEventId(event.getId(), 5, 5);
 
         assertThat(result.totalReviewCount()).isEqualTo(2);
-        assertThat(result.averageRating()).isEqualTo((review1.getRating() + review2.getRating()) / 2.0);
     }
   
     @Test


### PR DESCRIPTION
## 📌 개요
이벤트별 리뷰 조회 API의 성능을 개선하기 위해 진행한 최적화 작업 내용을 정리합니다. 

## 🛠️ 작업 내용
- [ ] 변경 사항 요약
- [ ] 주요 변경 사항 설명
- [ ] 관련 이슈 번호 (`#159`)

## 기존 로직
이벤트 리뷰 조회 시 매번 평균 평점을 계산하는 방식과 회원의 이름을 가져오는 과정에서 N+1 문제로 인한 불필요한 쿼리 실행이 있었습니다.

## 개선 방법
1. 스케줄러를 통한 평균 평점 사전 계산 및 저장
2. Fetch Join과 복합 인덱스 추가를 통해 데이터베이스 성능을 최적화

## 문제 발생 시나리오
AWS t2.micro 성능과 최대한 비슷한 환경의 서버를 구동하고, 10,000개의 리뷰가 있는 이벤트를 대상으로 2분간 1,000명의 동시 사용자가 리뷰 조회를 요청하는 상황에서 성능을 측정했습니다.

### 기존 성능 문제점
- 매번 평균 계산: 페이지 조회 시마다 AVG(r.rating) 계산
- N+1 문제: 리뷰 조회 후 각 리뷰의 멤버 정보를 개별 쿼리로 조회
- 인덱스 부족: event_id와 created_at 조합 인덱스 없음
<img width="1189" height="680" alt="1 0" src="https://github.com/user-attachments/assets/7aa238d4-1610-4dab-b86a-169f8eddeed8" />

---

### 1단계: 스케줄 기반 평균 평점 사전 계산
기존 코드
```java
public EventReviewPageResponse getPagingReviewsByEventId(Long eventId, int page, int size) {
    PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
    Page<Review> reviewPage = reviewRepository.findPageByEventId(eventId, pageable);
    List<ReviewDetailResponse> reviewResponses = getReviewDetailResponsesFromReviewPage(reviewPage);
    Double averageRating = reviewRepository.getAverageByEventId(eventId); // 매번 계산
    return EventReviewPageResponse.of(reviewPage, reviewResponses, averageRating, page, size);
}
```
개선된 코드
```java
public EventReviewPageResponse getPagingReviewsByEventId(Long eventId, int page, int size) {
    PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
    Page<Review> reviewPage = reviewRepository.findPageByEventId(eventId, pageable);
    List<ReviewDetailResponse> reviewResponses = getReviewDetailResponsesFromReviewPage(reviewPage);
    Event event = eventRepository.getOrThrow(eventId); // 이벤트 객체에서 조회
    return EventReviewPageResponse.of(reviewPage, reviewResponses, event.getAverageRating(), page, size);
}
```
스케줄러 추가
```java
@Component
@RequiredArgsConstructor
@Transactional
public class ReviewAverageRatingScheduler {

    private final EventRepository eventRepository;
    private final ReviewRepository reviewRepository;

    @EventListener(ApplicationReadyEvent.class)

    public void initializeEventAverageRatings() {
        updateEventAverageRate();
    }

    @Scheduled(fixedRate = 30 * 60 * 1000) // 30분 마다 실행
    public void updateEventAverageRate() {
        List<Event> events = eventRepository.findAll();
        events.forEach(event -> {
            double averageRating = reviewRepository.getAverageByEventId(event.getId());
            event.updateAverageRating(averageRating);
        });
    }
}
```
### 1단계 개선 결과

- 총 요청: 24,602개 → 39,287개 (59.7% 증가)
- 평균 응답시간: 1,498ms → 671ms (55.2% 단축)
<img width="1189" height="684" alt="1 1" src="https://github.com/user-attachments/assets/35b4b73b-9865-4b7d-a54d-632456e94960" />

---

### 2단계: Fetch Join 및 인덱스 최적화
Fetch Join 적용
``` java
@Query(value = "SELECT r FROM Review r JOIN FETCH r.member WHERE r.event.id = :eventId",
       countQuery = "SELECT count(r) FROM Review r WHERE r.event.id = :eventId")
Page<Review> findPageByEventId(@Param("eventId") Long eventId, Pageable pageable);
```
복합 인덱스 추가
``` java
@Entity
@Table(indexes = @Index(name = "idx_review_event_created", columnList = "event_id, created_at DESC"))
public class Review {
    // 엔티티 내용
}
```
### 2단계 개선 결과
- 총 요청: 39,287개 → 66,932개 (70.4% 증가)
- 평균 응답시간: 671ms → 16ms (97.6% 단축)
<img width="1194" height="678" alt="1 2" src="https://github.com/user-attachments/assets/ad7f5273-b325-4eef-be4c-89bb98402a55" />

---
## 각 개선 방법의 장단점 분석
### 스케줄 기반 평균 평점 사전 계산
장점
- 실시간 조회 시 평균 계산 부하 제거
- 응답 시간 단축 및 일관성 보장

단점
- 실시간 정확성 감소 (최대 30분 지연)
- 추가 스케줄링 로직 필요

### Fetch Join
장점
- N+1 문제 해결로 쿼리 횟수 대폭 감소
- 한 번의 쿼리로 연관 데이터 모두 조회
- 네트워크 통신 비용 절약

단점
- 메모리 사용량 증가 (모든 연관 데이터 로드)
- 복잡한 연관 관계에서 성능 저하 가능성

---
## 개선 방법 선택 이유
프로젝트 구조상 이벤트 상세 조회에 가장 많은 부하가 발생합니다. 따라서 이벤트 예매 기능과 크게 관련없는 평균 평점의 경우 데이터의 실시간 정확성이 중요하지 않다고 판단하여 10~30분 단위의 스케줄링을 통해 조회 성능을 개선했습니다.
또한 리뷰를 페이지당 5개씩 가져오는 구조이므로, Fetch Join으로 인한 메모리 사용량 증가보다는 쿼리 수를 줄이는 방향이 성능 향상에 더 큰 도움이 된다고 판단했습니다.

## 결론 및 권장사항
###핵심 개선 요소
- 스케줄 기반 사전 계산: 실시간 계산 부하 제거
- Fetch Join + 복합 인덱스: N+1 문제 해결, 데이터베이스 쿼리 최적화

### 상황별 적용 가이드라인
대용량 데이터 + 높은 트래픽:
- 스케줄 기반 사전 계산 + 복합 인덱스 조합

실시간 정확성이 중요한 경우
- 스케줄 주기를 짧게 설정하거나 이벤트 기반 업데이트로 데이터 정합성을 확보

## 📌 테스트 케이스
- [ ] 기능 정상 동작 확인
- [ ] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [ ] 코드 스타일 및 컨벤션 준수 확인
- [ ] 기존 테스트 통과 여부 확인

### 📌 기타 참고 사항

배포된 환경에서 테스트를 진행하고 싶었지만 테스트에 익숙하지 않아 시간 관계상 로컬에서 최대한 비슷한 환경에서 테스트를 진행했습니다. 이로 인해 실제 배포 환경과 다른 성능이 나올 수 있습니다.

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.